### PR TITLE
Legg til tilgang for Team Helse Arbeidsgiver sine apper i dev

### DIFF
--- a/nais/dev-gcp-altinn-tilganger.yaml
+++ b/nais/dev-gcp-altinn-tilganger.yaml
@@ -60,6 +60,10 @@ spec:
           namespace: permittering-og-nedbemanning
         - application: mulighetsrommet-api
           namespace: team-mulighetsrommet
+        - application: fritakagp
+          namespace: helsearbeidsgiver
+        - application: im-altinn
+          namespace: helsearbeidsgiver
     outbound:
       external:
         - host: platform.tt02.altinn.no


### PR DESCRIPTION
Legg til tilgang for Team Helse Arbeidsgiver sine apper i dev Vi ønsker å erstatte altinn2 integrasjonen vi bruker i dag med dette apiet. Vi tenker å ta i bruk Tokenx i fritakagp og azure token i im-altinn.