### PR TITLE
metric på texas auth

### DIFF
--- a/src/main/kotlin/no/nav/fager/Application.kt
+++ b/src/main/kotlin/no/nav/fager/Application.kt
@@ -202,7 +202,7 @@ fun Application.ktorConfig(
         get("/") {
             call.respondRedirect("/swagger-ui")
         }
-        swaggerUI(path = "swagger-ui", swaggerFile = "api.yaml")
+        swaggerUI(path = "swagger-ui", swaggerFile = "openapi.yaml")
 
         route("/m2m") {
             install(TexasAuth) {

--- a/src/main/kotlin/no/nav/fager/infrastruktur/Http.kt
+++ b/src/main/kotlin/no/nav/fager/infrastruktur/Http.kt
@@ -49,6 +49,7 @@ fun defaultHttpClient(
 }
 
 val httpClientTaggedTimerTimer = ConcurrentHashMap<String, Timer>()
+
 fun withTimer(name: String): Timer =
     httpClientTaggedTimerTimer.computeIfAbsent(name) {
         Timer.builder("http_client")

--- a/src/main/kotlin/no/nav/fager/infrastruktur/Http.kt
+++ b/src/main/kotlin/no/nav/fager/infrastruktur/Http.kt
@@ -7,9 +7,11 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.network.sockets.*
 import io.ktor.serialization.kotlinx.json.*
+import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.serialization.json.Json
 import java.io.EOFException
+import java.util.concurrent.ConcurrentHashMap
 import javax.net.ssl.SSLHandshakeException
 
 fun defaultHttpClient(
@@ -45,3 +47,12 @@ fun defaultHttpClient(
 
     configure()
 }
+
+val httpClientTaggedTimerTimer = ConcurrentHashMap<String, Timer>()
+fun withTimer(name: String): Timer =
+    httpClientTaggedTimerTimer.computeIfAbsent(name) {
+        Timer.builder("http_client")
+            .tag("name", it)
+            .publishPercentileHistogram()
+            .register(Metrics.meterRegistry)
+    }

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -163,7 +163,26 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/no.nav.fager.AltinnTilgangerM2MRequest'
-        required: false
+            examples:
+              no_filter:
+                value:
+                  fnr: "11123456789"
+              filter_altinn2:
+                value:
+                  fnr: "11123456789"
+                  filter:
+                    altinn2Tilganger: [ "4936:1" ]
+              filter_altinn3:
+                value:
+                  fnr: "11123456789"
+                  filter:
+                    altinn3Tilganger: [ "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" ]
+              filter_altinn2og3:
+                value:
+                  fnr: "11123456789"
+                  filter:
+                    altinn2Tilganger: [ "4936:1" ]
+                    altinn3Tilganger: [ "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" ]
       responses:
         '200':
           description: Successful Request
@@ -219,6 +238,22 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/no.nav.fager.AltinnTilgangerRequest'
+            examples:
+              no_filter:
+                value: ""
+              filter_altinn2:
+                value:
+                  filter:
+                    altinn2Tilganger: [ "4936:1" ]
+              filter_altinn3:
+                value:
+                  filter:
+                    altinn3Tilganger: [ "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" ]
+              filter_altinn2og3:
+                value:
+                  filter:
+                    altinn2Tilganger: [ "4936:1" ]
+                    altinn3Tilganger: [ "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" ]
         required: false
       responses:
         '200':

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -240,6 +240,7 @@ paths:
               $ref: '#/components/schemas/no.nav.fager.AltinnTilgangerRequest'
             examples:
               no_filter:
+                value:
               filter_altinn2:
                 value:
                   filter:

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -240,7 +240,6 @@ paths:
               $ref: '#/components/schemas/no.nav.fager.AltinnTilgangerRequest'
             examples:
               no_filter:
-                value: ""
               filter_altinn2:
                 value:
                   filter:

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -165,19 +165,23 @@ paths:
               $ref: '#/components/schemas/no.nav.fager.AltinnTilgangerM2MRequest'
             examples:
               no_filter:
+                summary: Ingen filter
                 value:
                   fnr: "11123456789"
               filter_altinn2:
+                summary: filtrer på en eller flere altinn 2 tjenester
                 value:
                   fnr: "11123456789"
                   filter:
                     altinn2Tilganger: [ "4936:1" ]
               filter_altinn3:
+                summary: filtrer på en eller flere altinn 3 ressurser
                 value:
                   fnr: "11123456789"
                   filter:
                     altinn3Tilganger: [ "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" ]
-              filter_altinn2og3:
+              filter_altinn2eller3:
+                summary: filtrer på en eller flere altinn 2 tjenester og en eller flere altinn 3 ressurser
                 value:
                   fnr: "11123456789"
                   filter:
@@ -238,18 +242,23 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/no.nav.fager.AltinnTilgangerRequest'
+            required: false
             examples:
               no_filter:
-                value:
+                summary: Ingen filter (trenger ikke noe i body)
+                value: "{}"
               filter_altinn2:
+                summary: filtrer på en eller flere altinn 2 tjenester
                 value:
                   filter:
                     altinn2Tilganger: [ "4936:1" ]
               filter_altinn3:
+                summary: filtrer på en eller flere altinn 3 ressurser
                 value:
                   filter:
                     altinn3Tilganger: [ "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" ]
-              filter_altinn2og3:
+              filter_altinn2eller3:
+                summary: filtrer på en eller flere altinn 2 tjenester og en eller flere altinn 3 ressurser
                 value:
                   filter:
                     altinn2Tilganger: [ "4936:1" ]


### PR DESCRIPTION
sette opp et panel i dashboard for feil mot texas

legger også til en ny hjelpefunksjon for å registrere metrikker på andre http clienter. Dette i stedet for å videreføre httpclientmetrics plugin ala det vi gjør i produsent api.