### PR TITLE
Legg til tilgang for pia-sykefravarsstatistikk i dev-gcp (team pia)

### DIFF
--- a/nais/dev-gcp-altinn-tilganger.yaml
+++ b/nais/dev-gcp-altinn-tilganger.yaml
@@ -66,6 +66,8 @@ spec:
           namespace: helsearbeidsgiver
         - application: im-altinn
           namespace: helsearbeidsgiver
+        - application: pia-sykefravarsstatistikk
+          namespace: pia
     outbound:
       external:
         - host: platform.tt02.altinn.no


### PR DESCRIPTION
Legg til tilgang for pia-sykefravarsstatistikk i dev-gcp  
Applikasjon pia-sykefravarsstatistikk erstatter sykefravarsstatistikk-api (on-prem). Vi ønsker å bruke altinn-tilganger fra pia-sykefravarsstatistikk for å verifisere tilganger i Altinn for innloggede arbeidsigvere på min-side-arbeidsgiver/forebygge-fravær 