### PR TITLE
Legg til tilgang for forebyggingsplan i dev-gcp (team pia)

### DIFF
--- a/nais/dev-gcp-altinn-tilganger.yaml
+++ b/nais/dev-gcp-altinn-tilganger.yaml
@@ -68,6 +68,8 @@ spec:
           namespace: helsearbeidsgiver
         - application: pia-sykefravarsstatistikk
           namespace: pia
+        - application: forebyggingsplan
+          namespace: teamia
         - application: sosialhjelp-avtaler-api-dev
           namespace: teamdigisos
     outbound:


### PR DESCRIPTION
Applikasjon forebyggingsplan viser aktiviteter på min-side arbeidsgiver (forebygge-fravær). Vi ønsker å bruke altinn-tilganger fra forebyggingsplan for å verifisere tilganger i Altinn for innloggede arbeidsigvere på min-side-arbeidsgiver/forebygge-fravær.

Dette er en del av arbeidet teamet gjør med å migrere fra bruk av altinn-rettigheter-proxy til arbeidsgiver-altinn-tilganger