### PR TITLE
Legg til tilgang for fia-arbeidsgiver og ia-tjenester-metrikker i dev-gcp (team pia)

### DIFF
--- a/nais/dev-gcp-altinn-tilganger.yaml
+++ b/nais/dev-gcp-altinn-tilganger.yaml
@@ -68,6 +68,8 @@ spec:
           namespace: helsearbeidsgiver
         - application: pia-sykefravarsstatistikk
           namespace: pia
+        - application: fia-arbeidsgiver
+          namespace: pia
         - application: forebyggingsplan
           namespace: teamia
         - application: sosialhjelp-avtaler-api-dev

--- a/nais/dev-gcp-altinn-tilganger.yaml
+++ b/nais/dev-gcp-altinn-tilganger.yaml
@@ -72,6 +72,8 @@ spec:
           namespace: pia
         - application: forebyggingsplan
           namespace: teamia
+        - application: ia-tjenester-metrikker
+          namespace: arbeidsgiver
         - application: sosialhjelp-avtaler-api-dev
           namespace: teamdigisos
     outbound:


### PR DESCRIPTION
Applikasjonen fia-arbeidsgiver viser tilgjengeliggjør for min-side-arbeidsgiver om en virksomhet er med i et IA-samarbeid eller ikke (avhengig av tilganger i altinn)

Applikasjonen ia-tjenester-metrikker mottar og lagrer metrikker fra andre IA-applikasjoner for måling av mottatte ia-tjenester

Vi ønsker å bruke altinn-tilganger fra forebyggingsplan for å verifisere tilganger i Altinn for innloggede arbeidsigvere på min-side-arbeidsgiver/forebygge-fravær. Dette er en del av arbeidet teamet gjør med å migrere fra bruk av altinn-rettigheter-proxy til arbeidsgiver-altinn-tilganger

Lik #36 kommer mapping senere