### PR TITLE
Legg til tilgang for team Pia apper for prod-gcp

### DIFF
--- a/nais/prod-gcp-altinn-tilganger.yaml
+++ b/nais/prod-gcp-altinn-tilganger.yaml
@@ -63,6 +63,14 @@ spec:
           namespace: helsearbeidsgiver
         - application: sosialhjelp-avtaler-api
           namespace: teamdigisos
+        - application: pia-sykefravarsstatistikk
+          namespace: pia
+        - application: fia-arbeidsgiver
+          namespace: pia
+        - application: forebyggingsplan
+          namespace: teamia
+        - application: ia-tjenester-metrikker
+          namespace: arbeidsgiver
     outbound:
       external:
         - host: platform.altinn.no


### PR DESCRIPTION
Legger til tilgang for appene pia-sykefravarsstatistikk, fia-arbeidsgiver, forebyggingsplan og ia-tjenester-metrikker så de kan nå arbeidsgiver-altinn-tilganger.

Vi ønsker å bruke altinn-tilganger fra forebyggingsplan for å verifisere tilganger i Altinn (altinn-2 for øyeblikket) for innloggede arbeidsgivere på min-side-arbeidsgiver/forebygge-fravær. Dette er en del av arbeidet teamet gjør med å migrere fra bruk av altinn-rettigheter-proxy til arbeidsgiver-altinn-tilganger.

Applikasjon pia-sykefravarsstatistikk erstatter sykefravarsstatistikk-api (on-prem). Vi ønsker å bruke altinn-tilganger fra pia-sykefravarsstatistikk for å verifisere tilganger i Altinn for innloggede arbeidsigvere på min-side-arbeidsgiver/forebygge-fravær

Applikasjon forebyggingsplan viser aktiviteter på min-side arbeidsgiver (forebygge-fravær). Vi ønsker å bruke altinn-tilganger fra forebyggingsplan for å verifisere tilganger i Altinn for innloggede arbeidsigvere på min-side-arbeidsgiver/forebygge-fravær.

Applikasjonen fia-arbeidsgiver viser tilgjengeliggjør for min-side-arbeidsgiver om en virksomhet er med i et IA-samarbeid eller ikke (avhengig av tilganger i altinn)

Applikasjonen ia-tjenester-metrikker mottar og lagrer metrikker fra andre IA-applikasjoner for måling av mottatte ia-tjenester
