### PR TITLE
WIP: Støtte for henting av slettede virksomheter og underenheter

### DIFF
--- a/src/main/kotlin/no/nav/fager/Api.kt
+++ b/src/main/kotlin/no/nav/fager/Api.kt
@@ -13,6 +13,7 @@ data class AltinnTilgang(
     val underenheter: List<AltinnTilgang>,
     val navn: String,
     val organisasjonsform: String,
+    val erSlettet: Boolean
 )
 
 annotation class Example(val value: String)
@@ -85,15 +86,18 @@ data class Filter(
 @Serializable
 sealed class AltinnTilgangerRequestBase {
     abstract val filter: Filter
+    abstract val inkluderSlettede: Boolean
 }
 
 @Serializable
 data class AltinnTilgangerRequest(
     override val filter: Filter = Filter.empty,
-) : AltinnTilgangerRequestBase()
+    override val inkluderSlettede: Boolean = false,
+    ) : AltinnTilgangerRequestBase()
 
 @Serializable
 data class AltinnTilgangerM2MRequest(
     val fnr: String,
     override val filter: Filter = Filter.empty,
-) : AltinnTilgangerRequestBase()
+    override val inkluderSlettede: Boolean = false,
+    ) : AltinnTilgangerRequestBase()

--- a/src/main/kotlin/no/nav/fager/redis/Redis.kt
+++ b/src/main/kotlin/no/nav/fager/redis/Redis.kt
@@ -97,18 +97,18 @@ interface RedisCodec<K, V> {
 }
 
 interface AltinnTilgangerRedisClient {
-    suspend fun get(fnr: String): AltinnTilgangerResultat?
-    suspend fun set(fnr: String, altinnTilganger: AltinnTilgangerResultat)
+    suspend fun get(cacheKey: String): AltinnTilgangerResultat?
+    suspend fun set(cacheKey: String, altinnTilganger: AltinnTilgangerResultat)
 }
 
 class AltinnTilgangerRedisClientImpl(redisConfig: RedisConfig) : AltinnTilgangerRedisClient {
     private val redisClient = redisConfig.createClient<AltinnTilgangerResultat>("altinn-tilganger")
 
-    override suspend fun get(fnr: String) = redisClient.get(fnr.hashed())
+    override suspend fun get(cacheKey: String) = redisClient.get(cacheKey.hashed())
 
-    override suspend fun set(fnr: String, altinnTilganger: AltinnTilgangerResultat) {
+    override suspend fun set(cacheKey: String, altinnTilganger: AltinnTilgangerResultat) {
         redisClient.set(
-            fnr.hashed(),
+            cacheKey.hashed(),
             altinnTilganger,
             SetParams().ex(Duration.ofMinutes(10).seconds)
         )

--- a/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
@@ -72,7 +72,8 @@ class AltinnServiceTest {
                             altinn2Tilganger = setOf("4936:1"),
                             underenheter = listOf(),
                             navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     )
                 )
@@ -97,7 +98,8 @@ class AltinnServiceTest {
                             altinn2Tilganger = setOf("4936:1"),
                             underenheter = listOf(),
                             navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     )
                 )

--- a/src/test/kotlin/no/nav/fager/AltinnTilgangerResultatTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnTilgangerResultatTest.kt
@@ -18,7 +18,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("4936:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 ),
             )
         ).filter(Filter.empty).let {
@@ -38,7 +39,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("4936:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 ),
                 AltinnTilgang(
                     orgnr = "2",
@@ -46,7 +48,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("bar:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -67,7 +70,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("bar:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 ),
                 AltinnTilgang(
                     orgnr = "2",
@@ -75,7 +79,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("4936:1", "bar:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -105,11 +110,13 @@ class AltinnTilgangerResultatTest {
                             altinn2Tilganger = setOf("4936:1"),
                             underenheter = listOf(),
                             navn = "Donald Duck & Co Avd. Andebyen",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     ),
                     navn = "Donald Duck & Co",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -141,7 +148,8 @@ class AltinnTilgangerResultatTest {
                             altinn2Tilganger = setOf("bar:none"),
                             underenheter = listOf(),
                             navn = "2",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         ),
                         AltinnTilgang(
                             orgnr = "3",
@@ -149,11 +157,13 @@ class AltinnTilgangerResultatTest {
                             altinn2Tilganger = setOf("bar:none"),
                             underenheter = listOf(),
                             navn = "3",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     ),
                     navn = "1",
-                    organisasjonsform = "AS"
+                    organisasjonsform = "AS",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -330,11 +340,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "NAV ØKONOMILINJEN",
-          "organisasjonsform": "ORGL"
+          "organisasjonsform": "ORGL",
+          "erSlettet": false
         }
       ],
       "navn": "Arbeids- og Velferdsetaten",
-      "organisasjonsform": "ORGL"
+      "organisasjonsform": "ORGL",
+      "erSlettet": false
     },
     {
       "orgnr": "910825836",
@@ -351,7 +363,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "HEGGEDAL OG KLOKKARVIK REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825631",
@@ -361,7 +374,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "AKKARVIK OG MJÅVATN REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825658",
@@ -371,11 +385,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "KJERRGARDEN OG SIREVÅG REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "BEKKESTUA OG VIKESÅ REGNSKAP",
-      "organisasjonsform": "ORGL"
+      "organisasjonsform": "ORGL",
+      "erSlettet": false
     },
     {
       "orgnr": "811306312",
@@ -400,7 +416,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG EIDSLANDET",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811307432",
@@ -414,7 +431,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG ULNES",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811307122",
@@ -428,7 +446,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG SÆTERVIK",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811306932",
@@ -442,7 +461,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG HAMARØY",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811307602",
@@ -456,11 +476,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG ABELVÆR",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "DAVIK OG HORTEN",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "911000474",
@@ -470,7 +492,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "ENEBAKK OG SANDSHAMN REVISJON",
-      "organisasjonsform": "STI"
+      "organisasjonsform": "STI",
+      "erSlettet": false
     },
     {
       "orgnr": "910825321",
@@ -483,11 +506,13 @@ private val sampleJSON = """
           "altinn2Tilganger": [],
           "underenheter": [],
           "navn": "BYGSTAD OG VINTERBRO REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "FANNREM OG VIKERSUND REGNSKAP",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910831992",
@@ -504,11 +529,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "HAUKEDALEN OG SULA REVISJON",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "KVALØYSLETTA OG ØRSTA REGNSKAP",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "911003155",
@@ -518,7 +545,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "LALM OG NARVIK REVISJON",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "810825472",
@@ -572,7 +600,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "GAMLE FREDRIKSTAD OG RAMNES REGNSK",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825496",
@@ -601,7 +630,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "SLEMMESTAD OG STAVERN REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825518",
@@ -629,11 +659,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "MAURA OG KOLBU REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "MALMEFJORDEN OG RIDABU REGNSKAP",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "911309068",
@@ -643,7 +675,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "ORRE OG VIK I SOGN",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "314088700",
@@ -660,11 +693,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "PUSLETE LYSTIG TIGER AS",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "PUSLETE LYSTIG TIGER AS",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910712284",
@@ -681,7 +716,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "HUNNDALEN OG NEVERDAL",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712314",
@@ -691,7 +727,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "STAMSUND OG KVÅS",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712330",
@@ -701,11 +738,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "SALTRØD OG HØNSEBY",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "REKDAL OG PORSGRUNN",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910949446",
@@ -715,7 +754,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "SAND OG TONSTAD REVISJON",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910831259",
@@ -725,7 +765,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "STABBESTAD OG SILDA REGNSKAP",
-      "organisasjonsform": "ENK"
+      "organisasjonsform": "ENK",
+      "erSlettet": false
     },
     {
       "orgnr": "910753282",
@@ -742,11 +783,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "ÅFJORD OG GJERSTAD",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "STORÅS OG HESSENG",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910712217",
@@ -779,7 +822,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "ULNES OG SÆBØ",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712268",
@@ -797,7 +841,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "ENEBAKK OG ØYER",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712233",
@@ -815,11 +860,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "UTVIK OG ETNE",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "STØ OG BERGER",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910825550",
@@ -853,7 +900,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "LINESØYA OG LANGANGEN REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825607",
@@ -872,7 +920,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "BIRTAVARRE OG VÆRLANDET REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825569",
@@ -890,11 +939,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "STORFOSNA OG FREDRIKSTAD REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "TRANØY OG SANDE I VESTFOLD REGNSKA",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     }
   ]
 }

--- a/src/test/kotlin/no/nav/fager/RedisIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fager/RedisIntegrationTest.kt
@@ -66,11 +66,13 @@ private val altinnTilganger = AltinnTilgangerResultat(
                     altinn2Tilganger = setOf("4936:1"),
                     underenheter = listOf(),
                     navn = "Donald Duck & Co Avd. Andebyen",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 )
             ),
             navn = "Donald Duck & Co",
-            organisasjonsform = "AS"
+            organisasjonsform = "AS",
+            erSlettet = false
         )
     )
 )

--- a/src/test/kotlin/no/nav/fager/fakes/clients/FakeRedisClient.kt
+++ b/src/test/kotlin/no/nav/fager/fakes/clients/FakeRedisClient.kt
@@ -8,13 +8,13 @@ class FakeRedisClient(
     private val cache: MutableMap<String, AltinnService.AltinnTilgangerResultat> = mutableMapOf(),
 ) : AltinnTilgangerRedisClient, FakeClientBase() {
 
-    override suspend fun get(fnr: String): AltinnService.AltinnTilgangerResultat? {
-        addFunctionCall(this::get.name, fnr)
-        return cache[fnr]
+    override suspend fun get(cacheKey: String): AltinnService.AltinnTilgangerResultat? {
+        addFunctionCall(this::get.name, cacheKey)
+        return cache[cacheKey]
     }
 
-    override suspend fun set(fnr: String, altinnTilganger: AltinnService.AltinnTilgangerResultat) {
-        addFunctionCall(this::set.name, fnr, altinnTilganger)
-        cache[fnr] = altinnTilganger
+    override suspend fun set(cacheKey: String, altinnTilganger: AltinnService.AltinnTilgangerResultat) {
+        addFunctionCall(this::set.name, cacheKey, altinnTilganger)
+        cache[cacheKey] = altinnTilganger
     }
 }


### PR DESCRIPTION
Det er nå mulig å hente slettede virksomheter og underenheter ved behov.

Hva er nytt:
- Man kan sende `{ "inkluderSlettede": true }` i request-body for å inkludere slettede enheter.
- Responsen inkluderer nå en `erSlettet`-boolean for hver virksomhet/underenhet.
- Cache-nøkkelen endres til `$fnr-med-slettede` dersom man etterspør slettede enheter.

TODO:
- Verifisere løsning
- Må legge til bruk i dokumentasjon
- Må vi gjøre det samme for AltInn2 `Status: Active`?
- Noe vi trenger å tenke på ifht. altinntilganger response

Endringer:
- Cache alle (inkludert slettede)
- Legge inkluderSlettede i filter