### PR TITLE
Støtte for henting av slettede virksomheter og underenheter

### DIFF
--- a/src/main/kotlin/no/nav/fager/Api.kt
+++ b/src/main/kotlin/no/nav/fager/Api.kt
@@ -13,6 +13,7 @@ data class AltinnTilgang(
     val underenheter: List<AltinnTilgang>,
     val navn: String,
     val organisasjonsform: String,
+    val erSlettet: Boolean
 )
 
 annotation class Example(val value: String)
@@ -60,6 +61,7 @@ fun <T> flatten(
 data class Filter(
     val altinn2Tilganger: Set<String> = emptySet(),
     val altinn3Tilganger: Set<String> = emptySet(),
+    val inkluderSlettede: Boolean = false,
 ) {
     init {
         altinn2Tilganger.forEach {
@@ -78,7 +80,7 @@ data class Filter(
         get() = altinn2Tilganger.isEmpty() && altinn3Tilganger.isEmpty()
 
     companion object {
-        val empty = Filter(emptySet(), emptySet())
+        val empty = Filter(emptySet(), emptySet(), false)
     }
 }
 

--- a/src/main/kotlin/no/nav/fager/altinn/AltinnService.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/AltinnService.kt
@@ -66,7 +66,7 @@ class AltinnService(
 
         val orgnrTilAltinn2Mapped = altinn3Tilganger.flatMap {
             flatten(it) { party ->
-                if (party.organizationNumber == null || party.unitType == null || party.isDeleted) {
+                if (party.organizationNumber == null || party.unitType == null) {
                     null
                 } else {
                     party.organizationNumber to party.authorizedResources.mapNotNull { resource ->
@@ -97,7 +97,7 @@ class AltinnService(
 
         return authorizedParties
             .mapNotNull { party ->
-                if (party.organizationNumber == null || party.unitType == null || party.isDeleted) {
+                if (party.organizationNumber == null || party.unitType == null) {
                     null
                 } else {
                     AltinnTilgang(
@@ -109,6 +109,7 @@ class AltinnService(
                             """${it.serviceCode}:${it.serviceEdition}"""
                         }?.toSet() ?: emptySet(),
                         underenheter = mapToHierarchy(party.subunits, altinn2Tilganger),
+                        erSlettet = party.isDeleted
                     )
                 }
             }
@@ -119,14 +120,11 @@ class AltinnService(
         val isError: Boolean,
         val altinnTilganger: List<AltinnTilgang>
     ) {
-        fun filter(filter: Filter) = if (filter.isEmpty) {
-            this
-        } else {
+        fun filter(filter: Filter): AltinnTilgangerResultat =
             AltinnTilgangerResultat(
                 isError,
                 altinnTilganger.filterRecursive(filter)
             )
-        }
     }
 }
 
@@ -142,27 +140,33 @@ class AltinnService(
  * så fjernes også overordnet enhet. Dette uavhengig om overordnet enhet har tilgangen definert eller ikke.
  */
 private fun List<AltinnTilgang>.filterRecursive(filter: Filter, parent: AltinnTilgang? = null): List<AltinnTilgang> =
-    mapNotNull {
-        val underenheter = it.underenheter.filterRecursive(filter, it)
-        val alleUnderenheterFjernet = underenheter.isEmpty() && it.underenheter.isNotEmpty()
-        if (alleUnderenheterFjernet) {
-            val filterMatchAltinn2 = (it.altinn2Tilganger intersect filter.altinn2Tilganger).isNotEmpty()
-            val filterMatchAltinn3 = (it.altinn3Tilganger intersect filter.altinn3Tilganger).isNotEmpty()
+    mapNotNull { tilgang ->
+        if (!filter.inkluderSlettede && tilgang.erSlettet) {
+            return@mapNotNull null
+        }
 
-            if (filterMatchAltinn2 || filterMatchAltinn3) {
+        val filtrerteUnderenheter = tilgang.underenheter.filterRecursive(filter, tilgang)
+
+        val alleUnderenheterFjernet = filtrerteUnderenheter.isEmpty() && tilgang.underenheter.isNotEmpty()
+        if (alleUnderenheterFjernet && !filter.isEmpty) {
+            val matcherAltinn2 = tilgang.altinn2Tilganger intersects filter.altinn2Tilganger
+            val matcherAltinn3 = tilgang.altinn3Tilganger intersects filter.altinn3Tilganger
+
+            if (matcherAltinn2 || matcherAltinn3) {
                 logger().error("Tom overordnet enhet som matcher filter fjernet pga alle underenheter fjernet")
             }
-            null
-        } else {
-            it.copy(underenheter = underenheter)
+            return@mapNotNull null
         }
-    }.filterIndexed { idx, it ->
-        val filterMatchAltinn2 = (it.altinn2Tilganger intersect filter.altinn2Tilganger).isNotEmpty()
-        val filterMatchAltinn3 = (it.altinn3Tilganger intersect filter.altinn3Tilganger).isNotEmpty()
-        val isLeaf = it.underenheter.isEmpty()
 
-        // hopp over hvis dette ikke er en løvnøde (virksomhet)
-        !isLeaf || filterMatchAltinn2 || filterMatchAltinn3
+        tilgang.copy(underenheter = filtrerteUnderenheter)
+    }.filter { tilgang ->
+        if (filter.isEmpty) return@filter true
+
+        val matcherAltinn2 = tilgang.altinn2Tilganger intersects filter.altinn2Tilganger
+        val matcherAltinn3 = tilgang.altinn3Tilganger intersects filter.altinn3Tilganger
+        val erLeaf = tilgang.underenheter.isEmpty()
+
+        !erLeaf || matcherAltinn2 || matcherAltinn3
     }
 
 private fun AuthorizedParty.addAuthorizedResourcesRecursive(
@@ -188,3 +192,6 @@ private fun <T> flatten(
 ): List<T> = listOfNotNull(
     mapFn(party)
 ) + party.subunits.flatMap { flatten(it, mapFn) }
+
+private infix fun <T> Set<T>.intersects(other: Set<T>): Boolean =
+    this.any { it in other }

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -179,6 +179,11 @@ paths:
                 summary: Ingen filter
                 value:
                   fnr: "11123456789"
+              filter_inkluder_slettede:
+                summary: returnerer også slettede underenheter
+                value:
+                  filter:
+                    inkluderSlettede: true
               filter_altinn2:
                 summary: filtrer på en eller flere altinn 2 tjenester
                 value:
@@ -258,6 +263,11 @@ paths:
               no_filter:
                 summary: Ingen filter (trenger ikke noe i body)
                 value: "{}"
+              filter_inkluder_slettede:
+                summary: returnerer også slettede underenheter
+                value:
+                  filter:
+                    inkluderSlettede: true
               filter_altinn2:
                 summary: filtrer på en eller flere altinn 2 tjenester
                 value:
@@ -320,6 +330,13 @@ components:
           items:
             title: String
             type: string
+        inkluderSlettede:
+          title: Inkluder slettede
+          type: boolean
+          description: |
+            Dersom true, vil også slettede virksomheter og underenheter inkluderes i resultatet.
+            Default er false, og slettede enheter filtreres da bort.
+          default: false
       description: >-
 
         Filter for hvilke tilganger som skal hentes. Dersom flere filter er
@@ -400,6 +417,13 @@ components:
           items:
             title: String
             type: string
+        inkluderSlettede:
+          title: Inkluder slettede
+          type: boolean
+          description: |
+            Dersom true, vil også slettede virksomheter og underenheter inkluderes i resultatet.
+            Default er false, og slettede enheter filtreres da bort.
+          default: false
         navn:
           title: String
           type: string

--- a/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
@@ -72,7 +72,8 @@ class AltinnServiceTest {
                             altinn2Tilganger = setOf("4936:1"),
                             underenheter = listOf(),
                             navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     )
                 )
@@ -97,7 +98,8 @@ class AltinnServiceTest {
                             altinn2Tilganger = setOf("4936:1"),
                             underenheter = listOf(),
                             navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     )
                 )

--- a/src/test/kotlin/no/nav/fager/AltinnTilgangerResultatTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnTilgangerResultatTest.kt
@@ -18,7 +18,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("4936:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 ),
             )
         ).filter(Filter.empty).let {
@@ -38,7 +39,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("4936:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 ),
                 AltinnTilgang(
                     orgnr = "2",
@@ -46,7 +48,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("bar:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -67,7 +70,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("bar:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 ),
                 AltinnTilgang(
                     orgnr = "2",
@@ -75,7 +79,8 @@ class AltinnTilgangerResultatTest {
                     altinn2Tilganger = setOf("4936:1", "bar:1"),
                     underenheter = listOf(),
                     navn = "SLEMMESTAD OG STAVERN REGNSKAP",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -105,11 +110,13 @@ class AltinnTilgangerResultatTest {
                             altinn2Tilganger = setOf("4936:1"),
                             underenheter = listOf(),
                             navn = "Donald Duck & Co Avd. Andebyen",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     ),
                     navn = "Donald Duck & Co",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -141,7 +148,8 @@ class AltinnTilgangerResultatTest {
                             altinn2Tilganger = setOf("bar:none"),
                             underenheter = listOf(),
                             navn = "2",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         ),
                         AltinnTilgang(
                             orgnr = "3",
@@ -149,11 +157,13 @@ class AltinnTilgangerResultatTest {
                             altinn2Tilganger = setOf("bar:none"),
                             underenheter = listOf(),
                             navn = "3",
-                            organisasjonsform = "BEDR"
+                            organisasjonsform = "BEDR",
+                            erSlettet = false
                         )
                     ),
                     navn = "1",
-                    organisasjonsform = "AS"
+                    organisasjonsform = "AS",
+                    erSlettet = false
                 )
             )
         ).filter(
@@ -301,7 +311,6 @@ class AltinnTilgangerResultatTest {
 private fun List<AltinnTilgang>.alleOrgn(): List<String> = flatten { it.orgnr }
 
 
-
 /* count occurrences of altinn2Tilganger
 sample.altinnTilganger.flatten {
     it.altinn2Tilganger
@@ -330,11 +339,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "NAV ØKONOMILINJEN",
-          "organisasjonsform": "ORGL"
+          "organisasjonsform": "ORGL",
+          "erSlettet": false
         }
       ],
       "navn": "Arbeids- og Velferdsetaten",
-      "organisasjonsform": "ORGL"
+      "organisasjonsform": "ORGL",
+      "erSlettet": false
     },
     {
       "orgnr": "910825836",
@@ -351,7 +362,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "HEGGEDAL OG KLOKKARVIK REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825631",
@@ -361,7 +373,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "AKKARVIK OG MJÅVATN REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825658",
@@ -371,11 +384,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "KJERRGARDEN OG SIREVÅG REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "BEKKESTUA OG VIKESÅ REGNSKAP",
-      "organisasjonsform": "ORGL"
+      "organisasjonsform": "ORGL",
+      "erSlettet": false
     },
     {
       "orgnr": "811306312",
@@ -400,7 +415,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG EIDSLANDET",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811307432",
@@ -414,7 +430,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG ULNES",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811307122",
@@ -428,7 +445,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG SÆTERVIK",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811306932",
@@ -442,7 +460,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG HAMARØY",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "811307602",
@@ -456,11 +475,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "DAVIK OG ABELVÆR",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "DAVIK OG HORTEN",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "911000474",
@@ -470,7 +491,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "ENEBAKK OG SANDSHAMN REVISJON",
-      "organisasjonsform": "STI"
+      "organisasjonsform": "STI",
+      "erSlettet": false
     },
     {
       "orgnr": "910825321",
@@ -483,11 +505,13 @@ private val sampleJSON = """
           "altinn2Tilganger": [],
           "underenheter": [],
           "navn": "BYGSTAD OG VINTERBRO REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "FANNREM OG VIKERSUND REGNSKAP",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910831992",
@@ -504,11 +528,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "HAUKEDALEN OG SULA REVISJON",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "KVALØYSLETTA OG ØRSTA REGNSKAP",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "911003155",
@@ -518,7 +544,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "LALM OG NARVIK REVISJON",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "810825472",
@@ -572,7 +599,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "GAMLE FREDRIKSTAD OG RAMNES REGNSK",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825496",
@@ -601,7 +629,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "SLEMMESTAD OG STAVERN REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825518",
@@ -629,11 +658,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "MAURA OG KOLBU REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "MALMEFJORDEN OG RIDABU REGNSKAP",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "911309068",
@@ -643,7 +674,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "ORRE OG VIK I SOGN",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "314088700",
@@ -660,11 +692,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "PUSLETE LYSTIG TIGER AS",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "PUSLETE LYSTIG TIGER AS",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910712284",
@@ -681,7 +715,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "HUNNDALEN OG NEVERDAL",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712314",
@@ -691,7 +726,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "STAMSUND OG KVÅS",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712330",
@@ -701,11 +737,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "SALTRØD OG HØNSEBY",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "REKDAL OG PORSGRUNN",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910949446",
@@ -715,7 +753,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "SAND OG TONSTAD REVISJON",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910831259",
@@ -725,7 +764,8 @@ private val sampleJSON = """
       ],
       "underenheter": [],
       "navn": "STABBESTAD OG SILDA REGNSKAP",
-      "organisasjonsform": "ENK"
+      "organisasjonsform": "ENK",
+      "erSlettet": false
     },
     {
       "orgnr": "910753282",
@@ -742,11 +782,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "ÅFJORD OG GJERSTAD",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "STORÅS OG HESSENG",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910712217",
@@ -779,7 +821,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "ULNES OG SÆBØ",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712268",
@@ -797,7 +840,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "ENEBAKK OG ØYER",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910712233",
@@ -815,11 +859,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "UTVIK OG ETNE",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "STØ OG BERGER",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     },
     {
       "orgnr": "910825550",
@@ -853,7 +899,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "LINESØYA OG LANGANGEN REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825607",
@@ -872,7 +919,8 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "BIRTAVARRE OG VÆRLANDET REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         },
         {
           "orgnr": "910825569",
@@ -890,11 +938,13 @@ private val sampleJSON = """
           ],
           "underenheter": [],
           "navn": "STORFOSNA OG FREDRIKSTAD REGNSKAP",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "TRANØY OG SANDE I VESTFOLD REGNSKA",
-      "organisasjonsform": "AS"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     }
   ]
 }

--- a/src/test/kotlin/no/nav/fager/AltinnTilgangerTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnTilgangerTest.kt
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AltinnTilgangerTest {
     companion object {
@@ -569,5 +571,127 @@ class AltinnTilgangerTest {
             assertEquals(HttpStatusCode.BadRequest, status)
         }
     }
-}
 
+    @Test
+    fun `inkluderSlettede = true returnerer også slettede underenheter`() = app.runTest {
+        app.altinn3Response(Post, "/accessmanagement/api/v1/resourceowner/authorizedparties") {
+            call.respondText(
+                //language=json
+                """
+                [
+                  {
+                    "partyUuid": "a1c831cf-c7b7-4e5e-9910-2ad9a05b4ec1",
+                    "name": "MALMEFJORDEN OG RIDABU REGNSKAP",
+                    "organizationNumber": "810825472",
+                    "personId": null,
+                    "partyId": 50166368,
+                    "type": "Organization",
+                    "unitType": "AS",
+                    "isDeleted": false,
+                    "onlyHierarchyElementWithNoAccess": true,
+                    "authorizedResources": ["test-fager"],
+                    "authorizedRoles": [],
+                    "subunits": [
+                      {
+                        "partyUuid": "8656eab6-119b-4691-8a8a-6f51a203aba7",
+                        "name": "SLEMMESTAD OG STAVERN REGNSKAP",
+                        "organizationNumber": "910825496",
+                        "personId": null,
+                        "partyId": 50169034,
+                        "type": "Organization",
+                        "unitType": "BEDR",
+                        "isDeleted": false,
+                        "onlyHierarchyElementWithNoAccess": false,
+                        "authorizedResources": [
+                          "test-fager"
+                        ],
+                        "authorizedRoles": [],
+                        "subunits": []
+                      },
+                      {
+                        "partyUuid": "8656bbb6-119b-4691-8a8a-6f51a203bba7",
+                        "name": "SLEMMESTAD OG STAVERN REGNSKAP 2",
+                        "organizationNumber": "910825554",
+                        "personId": null,
+                        "partyId": 50169035,
+                        "type": "Organization",
+                        "unitType": "BEDR",
+                        "isDeleted": false,
+                        "onlyHierarchyElementWithNoAccess": false,
+                        "authorizedResources": [],
+                        "authorizedRoles": [
+                          "DAGL"
+                        ],
+                        "subunits": []
+                      },
+                      {
+                        "partyUuid": "7756eab6-119b-4691-8a8a-6f51a203aba7",
+                        "name": "SLEMMESTAD OG STAVERN REGNSKAP SLETTET",
+                        "organizationNumber": "910825999",
+                        "personId": null,
+                        "partyId": 50169333,
+                        "type": "Organization",
+                        "unitType": "BEDR",
+                        "isDeleted": true,
+                        "onlyHierarchyElementWithNoAccess": false,
+                        "authorizedResources": [
+                          "test-fager"
+                        ],
+                        "authorizedRoles": [],
+                        "subunits": []
+                      }
+                    ]
+                  }
+                ]
+                """.trimIndent(), ContentType.Application.Json
+            )
+        }
+
+        val assertResponse: (AltinnTilgangerResponse) -> Unit = { virksomhet ->
+            val underenheter = virksomhet.hierarki[0].underenheter
+            val aktiv1 = underenheter.first { it.orgnr == "910825496" }
+            val aktiv2 = underenheter.first { it.orgnr == "910825554" }
+            val slettet = underenheter.first { it.orgnr == "910825999" }
+
+            assertEquals(3, underenheter.size)
+            assertFalse(aktiv1.erSlettet)
+            assertFalse(aktiv2.erSlettet)
+            assertTrue(slettet.erSlettet)
+        }
+
+        client.post("/altinn-tilganger") {
+            header("Authorization", "Bearer idporten-loa-high:${fnr.next()}")
+            contentType(ContentType.Application.Json)
+            setBody(
+                //language=json
+                """
+                {
+                  "filter": {
+                    "inkluderSlettede": true
+                  }
+                }
+                """.trimIndent()
+            )
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+        }.body<AltinnTilgangerResponse>().also(assertResponse)
+
+        client.post("/m2m/altinn-tilganger") {
+            header("Authorization", "Bearer fakem2mtoken")
+            contentType(ContentType.Application.Json)
+            setBody(
+                //language=json
+                """
+                {
+                    "fnr": "${fnr.next()}",
+                    "filter": {
+                      "inkluderSlettede": true
+                    }
+                }
+                """.trimIndent()
+            )
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+        }.body<AltinnTilgangerResponse>().also(assertResponse)
+    }
+}

--- a/src/test/kotlin/no/nav/fager/RedisIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fager/RedisIntegrationTest.kt
@@ -66,11 +66,13 @@ private val altinnTilganger = AltinnTilgangerResultat(
                     altinn2Tilganger = setOf("4936:1"),
                     underenheter = listOf(),
                     navn = "Donald Duck & Co Avd. Andebyen",
-                    organisasjonsform = "BEDR"
+                    organisasjonsform = "BEDR",
+                    erSlettet = true
                 )
             ),
             navn = "Donald Duck & Co",
-            organisasjonsform = "AS"
+            organisasjonsform = "AS",
+            erSlettet = true
         )
     )
 )


### PR DESCRIPTION
Det er nå mulig å hente slettede virksomheter og underenheter ved behov.

Hva er endret:
- Request-body støtter nå `{"inkluderSlettede": true}` i Filter for å inkludere slettede enheter.
- Responsen inkluderer en ny erSlettet flagg for hver virksomhet og underenhet.
- Dokumentasjon er oppdatert med informasjon om den nye funksjonaliteten.

TODO:
- Cache må enten slettes eller cache-key endres for å sikre at `erSlettet` reflekteres korrekt.
- Vurdere om tilsvarende logikk bør implementeres for Altinn2 (`Status: Active`).