### PR TITLE
bruk strukturert concurrency og fjern manuell CoroutineScope-injeksjon

### DIFF
--- a/src/main/kotlin/no/nav/fager/Application.kt
+++ b/src/main/kotlin/no/nav/fager/Application.kt
@@ -221,7 +221,6 @@ fun Application.ktorConfig(
                         altinnService.hentTilganger(
                             fnr = fnr,
                             filter = filter,
-                            scope = call
                         ).toResponse()
                     )
                 }
@@ -268,7 +267,6 @@ fun Application.ktorConfig(
                         altinnService.hentTilganger(
                             fnr = fnr,
                             filter = filter,
-                            scope = call
                         ).toResponse()
                     )
                 }

--- a/src/main/kotlin/no/nav/fager/altinn/Altinn2Client.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/Altinn2Client.kt
@@ -77,13 +77,10 @@ class Altinn2ClientImpl(
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun hentAltinn2Tilganger(fnr: String): Altinn2Tilganger {
         val reportees: List<ReporteeResult> = tjenester.asFlow()
-            .flowOn(Dispatchers.IO)
             .flatMapMerge { tjeneste ->
                 flow {
-                    this.emit(
-                        hentReportees(fnr, tjeneste.serviceCode, tjeneste.serviceEdition)
-                    )
-                }
+                    emit(hentReportees(fnr, tjeneste.serviceCode, tjeneste.serviceEdition))
+                }.flowOn(Dispatchers.IO)
             }.toList()
 
         return Altinn2Tilganger(

--- a/src/main/kotlin/no/nav/fager/altinn/Altinn2Client.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/Altinn2Client.kt
@@ -8,7 +8,11 @@ import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.nav.fager.infrastruktur.basedOnEnv
@@ -76,12 +80,13 @@ class Altinn2ClientImpl(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun hentAltinn2Tilganger(fnr: String): Altinn2Tilganger {
-        val reportees: List<ReporteeResult> = tjenester.asFlow()
-            .flatMapMerge { tjeneste ->
-                flow {
-                    emit(hentReportees(fnr, tjeneste.serviceCode, tjeneste.serviceEdition))
-                }.flowOn(Dispatchers.IO)
-            }.toList()
+        val reportees: List<ReporteeResult> = coroutineScope {
+            tjenester.map { tjeneste ->
+                async(Dispatchers.IO) {
+                    hentReportees(fnr, tjeneste.serviceCode, tjeneste.serviceEdition)
+                }
+            }.awaitAll()
+        }
 
         return Altinn2Tilganger(
             isError = reportees.any { it.isError },

--- a/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
@@ -59,7 +59,7 @@ class AltinnServiceTest {
         val fnr = "16120101181"
         val cacheKey = "$fnr-${AltinnService.CACHE_VERSION}"
 
-        altinnService.hentTilganger(fnr, Filter.empty, this)
+        altinnService.hentTilganger(fnr, Filter.empty)
 
         assertTrue(altinnRedisClient.getCallCountWithArgs(altinnRedisClient::get.name, cacheKey) == 1)
         assertTrue(
@@ -150,7 +150,7 @@ class AltinnServiceTest {
 
         val altinnService = AltinnService(altinn2Client, altinn3Client, altinnRedisClient, resourceRegistry)
 
-        altinnService.hentTilganger(fnr, Filter.empty, this)
+        altinnService.hentTilganger(fnr, Filter.empty)
 
         assertTrue(altinnRedisClient.getCallCountWithArgs(altinnRedisClient::get.name, cacheKey) == 1)
         assertTrue(altinnRedisClient.getCallCount(altinnRedisClient::set.name) == 0)
@@ -205,7 +205,7 @@ class AltinnServiceTest {
 
         val fnr = "16120101181"
         val cacheKey = "$fnr-${AltinnService.CACHE_VERSION}"
-        altinnService.hentTilganger(fnr, Filter.empty, this)
+        altinnService.hentTilganger(fnr, Filter.empty)
 
         assertTrue(altinnRedisClient.getCallCountWithArgs(altinnRedisClient::get.name, cacheKey) == 1)
         assertTrue(altinnRedisClient.getCallCount(altinnRedisClient::set.name) == 0)
@@ -264,8 +264,8 @@ class AltinnServiceTest {
         val cacheKey1 = "$fnr1-${AltinnService.CACHE_VERSION}"
         val cacheKey2 = "$fnr2-${AltinnService.CACHE_VERSION}"
 
-        altinnService.hentTilganger(fnr1, Filter.empty, this)
-        altinnService.hentTilganger(fnr2, Filter.empty, this)
+        altinnService.hentTilganger(fnr1, Filter.empty)
+        altinnService.hentTilganger(fnr2, Filter.empty)
 
         assertTrue(altinnRedisClient.getCallCount(altinnRedisClient::get.name) == 2)
         assertTrue(altinnRedisClient.getCallCountWithArgs(altinnRedisClient::get.name, cacheKey1) == 1)
@@ -313,7 +313,7 @@ class AltinnServiceTest {
         val altinnService = AltinnService(altinn2Client, altinn3Client, altinnRedisClient, resourceRegistry)
 
         val fnr = "16120101181"
-        val tilganger = altinnService.hentTilganger(fnr, Filter.empty, this)
+        val tilganger = altinnService.hentTilganger(fnr, Filter.empty)
 
         assertTrue(tilganger.altinnTilganger.count() == 1)
         assertTrue(tilganger.altinnTilganger.first { it.orgnr == "111111111" }.altinn2Tilganger.count() == 1)
@@ -383,7 +383,7 @@ class AltinnServiceTest {
         val fnr = "16120101181"
         val altinnService = AltinnService(altinn2Client, altinn3Client, altinnRedisClient, resourceRegistry)
 
-        val tilganger = altinnService.hentTilganger(fnr, Filter.empty, this)
+        val tilganger = altinnService.hentTilganger(fnr, Filter.empty)
         assertEquals(2, tilganger.altinnTilganger.size)
 
         tilganger.altinnTilganger.first { it.orgnr == "910825496" }.let { slemmestad ->
@@ -495,12 +495,12 @@ class AltinnServiceTest {
         val altinnService = AltinnService(altinn2Client, altinn3Client, altinnRedisClient, resourceRegistry)
 
         val fnr = "42"
-        val tilganger = altinnService.hentTilganger(fnr, Filter(setOf("4936:1")), this)
+        val tilganger = altinnService.hentTilganger(fnr, Filter(setOf("4936:1")))
         assertEquals(1, tilganger.altinnTilganger.size)
         assertEquals("2", tilganger.altinnTilganger.first().orgnr)
         assertEquals("2.1", tilganger.altinnTilganger.first().underenheter.first().orgnr)
 
-        val tilganger2 = altinnService.hentTilganger(fnr, Filter(setOf("4936:1")), this)
+        val tilganger2 = altinnService.hentTilganger(fnr, Filter(setOf("4936:1")))
         assertEquals(1, tilganger2.altinnTilganger.size)
         assertEquals("2", tilganger.altinnTilganger.first().orgnr)
         assertEquals("2.1", tilganger.altinnTilganger.first().underenheter.first().orgnr)


### PR DESCRIPTION
Vi får mange feil `arbeidsgiver-altinn-tilganger: Unhandled server error: "StandaloneCoroutine was cancelled"`. Denne forsøker å fikse dette ved å:

- Erstatter manuell injeksjon av CoroutineScope med structured concurrency via coroutineScope
- Erstatter bruk av Flow med parallelle async-kall for henting av Altinn 2-tilganger