### PR TITLE
feat: add open /resource-metadata endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ out/
 
 ### VS Code ###
 .vscode/
+.idea/copilotDiffState.xml

--- a/specifications/metadata_api.md
+++ b/specifications/metadata_api.md
@@ -1,0 +1,349 @@
+# Specification: Resource metadata API
+
+## Summary
+
+Add a new **open (no auth)** HTTP endpoint that returns, for every resource in
+`KnownResources`, the resource's metadata from Altinn Resource Registry
+(`title`, `rightDescription`, …) together with a flattened view of the policy
+subjects — `grantedByRoles` and `grantedByAccessPackages`.
+
+The endpoint is intended as a public "what tilganger/resources exist under NAV"
+listing that consumer teams can use without setting up authentication.
+
+## Endpoint
+
+```
+GET /resource-metadata
+```
+
+- **Authentication:** none. The route MUST NOT install `TexasAuth`.
+- **Caching:** response is derived from already-cached data (see
+  [Data sources](#data-sources)). The handler does no outbound HTTP itself.
+- **Content type:** `application/json`
+- **Status codes:**
+  - `200 OK` — always, as long as the app is ready.
+  - (fallback) `500 Internal Server Error` via existing `StatusPages` plugin.
+
+### Response shape
+
+```json
+{
+  "resources": {
+    "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger": {
+      "metadata": {
+        "title": {
+          "nb": "Innsyn i permitterings- og nedbemanningsmeldinger",
+          "nn": "…",
+          "en": "…"
+        },
+        "rightDescription": {
+          "nb": "…",
+          "nn": "…",
+          "en": "…"
+        },
+        "resourceType": "GenericAccessResource",
+        "status": "Completed",
+        "delegable": true
+      },
+      "grantedByRoles": ["dagl", "lede"],
+      "grantedByAccessPackages": ["regnskapsforer-lonn"]
+    }
+  }
+}
+```
+
+Top-level field name is `resources`. The map key is the
+`resourceId` from `KnownResources`.
+
+Per resource:
+
+- `metadata` — a projection of the Altinn resource document (see
+  [Data sources](#data-sources)). Use the raw Altinn shape for the fields
+  we pass through; do not translate or rename.
+- `grantedByRoles` — de-duplicated list of role codes, derived from policy
+  subjects where `type == "urn:altinn:rolecode"`. Use `policySubject.value`
+  verbatim (it is already the stripped id — e.g. `"dagl"`, `"knuf"`,
+  `"a0241"` — not the full `urn:altinn:rolecode:…` urn).
+- `grantedByAccessPackages` — de-duplicated list of access-package
+  identifiers, derived from policy subjects where
+  `type == "urn:altinn:accesspackage"`. Use `policySubject.value` verbatim
+  (e.g. `"regnskapsforer-lonn"`, not the full urn).
+
+Policy subjects with any other `type` are ignored. The full `urn` field is
+never exposed in the response — only the stripped id from `value`.
+
+Reference: example input from Altinn
+`GET /resourceregistry/api/v1/resource/{resourceId}/policy/subjects`
+
+```json
+{
+  "links": {},
+  "data": [
+    { "type": "urn:altinn:rolecode",      "value": "knuf",                "urn": "urn:altinn:rolecode:knuf" },
+    { "type": "urn:altinn:rolecode",      "value": "loper",               "urn": "urn:altinn:rolecode:loper" },
+    { "type": "urn:altinn:accesspackage", "value": "regnskapsforer-lonn", "urn": "urn:altinn:accesspackage:regnskapsforer-lonn" }
+  ]
+}
+```
+
+maps to `grantedByRoles: ["knuf", "loper"]`,
+`grantedByAccessPackages: ["regnskapsforer-lonn"]`.
+
+Ordering: response should be deterministic. Iterate `KnownResources` in
+declaration order; sort `grantedByRoles` and `grantedByAccessPackages`
+alphabetically.
+
+### Visibility
+
+The endpoint is **intentionally undocumented** in
+[src/main/resources/openapi.yaml](src/main/resources/openapi.yaml). Do not add
+it there, and do not reference it from the Swagger UI landing page. It is a
+hidden/internal-consumer route — discoverable only by teams we point at it
+directly. Keep the route handler itself minimal so there is nothing in the
+Swagger doc to forget to remove.
+
+## Data sources
+
+Two Altinn Resource Registry endpoints are involved. Both are unauthenticated
+from our side (the existing `resourceRegistryClient` in
+[Altinn3Client.kt](src/main/kotlin/no/nav/fager/altinn/Altinn3Client.kt) is a
+plain `defaultHttpClient()` with no token plugin).
+
+1. **Resource document** — NEW, needs to be added to `Altinn3Client`.
+   ```
+   GET {altinn3.baseUrl}/resourceregistry/api/v1/resource/{resourceId}
+   ```
+   Response contains localized `title` and `rightDescription` objects
+   (`{nb, nn, en}`), plus top-level fields like `resourceType`, `status`,
+   `delegable`, `identifier`. Only a subset is exposed in our response.
+
+2. **Policy subjects** — already implemented. See
+   `Altinn3Client.resourceRegistry_PolicySubjects` in
+   [Altinn3Client.kt:125](src/main/kotlin/no/nav/fager/altinn/Altinn3Client.kt:125).
+   Already cached via `ResourceRegistry.cache` with a 30-minute TTL and kept
+   fresh by a background job — we reuse this directly, do not re-fetch.
+
+## Implementation
+
+### 1. New DTOs (in [ResourceRegistry.kt](src/main/kotlin/no/nav/fager/altinn/ResourceRegistry.kt) or a new `ResourceMetadataApi.kt`)
+
+Use `kotlinx.serialization`, consistent with the rest of the codebase.
+
+```kotlin
+@Serializable
+data class LocalizedText(
+    val nb: String? = null,
+    val nn: String? = null,
+    val en: String? = null,
+)
+
+@Serializable
+data class ResourceRegistryResource(
+    val identifier: String,
+    val title: LocalizedText = LocalizedText(),
+    val rightDescription: LocalizedText = LocalizedText(),
+    val resourceType: String? = null,
+    val status: String? = null,
+    val delegable: Boolean? = null,
+)
+```
+
+The Altinn response has many more fields; mark all non-essential ones with
+defaults so unknown fields don't break deserialization. Configure
+`Json { ignoreUnknownKeys = true }` where this DTO is decoded
+(`resourceRegistryClient` is a separate `HttpClient` — configure its
+`ContentNegotiation` / `Json` accordingly, *or* decode manually with a
+permissive `Json` instance).
+
+### 2. Extend `Altinn3Client`
+
+Add to the interface and implementation in
+[Altinn3Client.kt](src/main/kotlin/no/nav/fager/altinn/Altinn3Client.kt):
+
+```kotlin
+suspend fun resourceRegistry_Resource(resourceId: String): Result<ResourceRegistryResource>
+```
+
+Implementation mirrors `resourceRegistry_PolicySubjects` — plain GET via
+`resourceRegistryClient`, no auth header, `runCatching { … }`.
+
+Path: `/resourceregistry/api/v1/resource/{resourceId}`.
+
+### 3. Extend `ResourceRegistry`
+
+Location: [ResourceRegistry.kt](src/main/kotlin/no/nav/fager/altinn/ResourceRegistry.kt).
+
+**Reuse the existing `policySubjectsPerResourceId` `AtomicReference`** — do
+not introduce a parallel policy-subjects state or a second background loop
+for subjects. The existing field (declared at
+[ResourceRegistry.kt:218](src/main/kotlin/no/nav/fager/altinn/ResourceRegistry.kt:218))
+is already populated and refreshed by
+`updatePolicySubjectsForKnownResources`; the new endpoint reads from it
+unchanged.
+
+What to add:
+
+1. **A second `RedisLoadingCache<ResourceRegistryResource>`** for the
+   resource document, alongside the existing policy-subject cache:
+   - `metricsName = "resource-registry-resource"`
+   - redis key namespace, e.g. `resource-registry-resource-v1`
+   - same `cacheTTL` (30 min)
+   - loader: `altinn3Client.resourceRegistry_Resource(resourceId).getOrThrow()`
+
+2. **A second `AtomicReference<Map<ResourceId, ResourceRegistryResource>>`**
+   (e.g. `resourceMetadataPerResourceId`) with the same initialization
+   pattern as `policySubjectsPerResourceId`:
+   ```kotlin
+   private val resourceMetadataPerResourceId = AtomicReference(
+       KnownResources.associate { it.resourceId to null as ResourceRegistryResource? }
+   )
+   ```
+
+3. **A parallel update function** — either generalize
+   `updatePolicySubjectsForKnownResources` into a generic
+   `updatePerKnownResource<T>(state, fetcher)` helper used by both flows, or
+   add a sibling `updateResourceMetadataForKnownResources`. Do NOT fold the
+   resource-document fetch into the policy-subjects loop — they should fail
+   independently so one broken upstream doesn't stall the other.
+
+4. **Readiness gating** — the existing `isReady` flag currently flips true
+   once policy subjects are warmed. Extend it so it only flips true once
+   **both** the policy-subject map and the resource-metadata map have been
+   warmed at least once. Startup sequence:
+   - launch existing policy-subjects warmup loop (unchanged)
+   - launch new resource-metadata warmup loop
+   - `isReady = policySubjectsReady && resourceMetadataReady`
+
+5. **Public accessors** — expose read-only views over the two
+   `AtomicReference`s. The existing `policySubjectsPerResourceId` is
+   `private`; add a public getter rather than changing its visibility so
+   callers can't mutate it:
+   ```kotlin
+   fun getPolicySubjects(): Map<ResourceId, List<PolicySubject>> =
+       policySubjectsPerResourceId.get()
+
+   fun getResourceMetadata(): Map<ResourceId, ResourceRegistryResource?> =
+       resourceMetadataPerResourceId.get()
+   ```
+
+Rationale: the open endpoint must not fan out to Altinn on the request path —
+it returns a pre-computed snapshot. Reusing `policySubjectsPerResourceId`
+means we pay zero extra cost for the subjects half of the response; the
+existing cache is already kept fresh for `AltinnService`.
+
+### 4. New response builder
+
+In a new file or alongside `Api.kt`:
+
+```kotlin
+@Serializable
+data class ResourceMetadataResponse(
+    val resources: Map<String, ResourceMetadataEntry>,
+)
+
+@Serializable
+data class ResourceMetadataEntry(
+    val metadata: ResourceRegistryResource,
+    val grantedByRoles: Set<String>,
+    val grantedByAccessPackages: Set<String>,
+)
+```
+
+Builder function — takes the two snapshots read from
+`ResourceRegistry.getResourceMetadata()` and
+`ResourceRegistry.getPolicySubjects()` (the latter is the existing
+`policySubjectsPerResourceId` state, reused):
+
+```kotlin
+fun buildResourceMetadataResponse(
+    metadata: Map<ResourceId, ResourceRegistryResource?>,
+    policySubjects: Map<ResourceId, List<PolicySubject>>,
+): ResourceMetadataResponse
+```
+
+Rules:
+
+- Iterate `KnownResources` in declaration order.
+- if `metadata[resourceId]` is missing fail the request and log an error.
+- For each resource, partition policy subjects by `type`:
+  - `"urn:altinn:rolecode"` → `grantedByRoles = subjects.map { it.value }.distinct().sorted()`
+  - `"urn:altinn:accesspackage"` → `grantedByAccessPackages = subjects.map { it.value }.distinct().sorted()`
+- Never emit `policySubject.urn` — only the stripped `value`.
+
+### 5. Wire up the route
+
+In [Application.kt](src/main/kotlin/no/nav/fager/Application.kt) inside the
+existing `routing { … }` block, add a top-level route with **no** `TexasAuth`
+install:
+
+```kotlin
+route("resource-metadata") {
+    get {
+        call.respond(
+            buildResourceMetadataResponse(
+                metadata = resourceRegistry.getResourceMetadata(),
+                policySubjects = resourceRegistry.getPolicySubjects(),
+            )
+        )
+    }
+}
+```
+
+Place it next to `swaggerUI(...)` — i.e. outside both `/m2m`, `/whoami`,
+`/altinn-tilganger` blocks — to make it obvious the route is unauthenticated.
+
+### 6. OpenAPI
+
+**Do not add this endpoint to
+[src/main/resources/openapi.yaml](src/main/resources/openapi.yaml).** The
+route is hidden by design — it must not appear in the Swagger UI.
+
+## Test plan
+
+Tests live in `src/test/kotlin/no/nav/fager/`. Follow the
+`testWithFakeApplication { app -> … }` pattern used in
+[AltinnTilgangerTest.kt](src/test/kotlin/no/nav/fager/AltinnTilgangerTest.kt).
+
+1. **Fake stubs** — extend
+   [FakeApplication.kt:48](src/test/kotlin/no/nav/fager/fakes/FakeApplication.kt:48)
+   so that every `resourceId` in `KnownResourceIds` also has a stub for
+   `GET /resourceregistry/api/v1/resource/{resourceId}` returning a canned
+   resource document. The stubs for policy subjects already exist.
+
+2. **Happy path** — `GET /resource-metadata` returns 200 with `resources`
+   containing an entry for every `KnownResourceId` in declaration order.
+   Assert metadata fields pass through and role/access-package extraction
+   works for the one known "roles" stub
+   (`nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger`
+   → `grantedByRoles = ["dagl", "lede"]`, using `value` verbatim).
+
+3. **No auth required** — hit the endpoint with no `Authorization` header
+   and assert 200. Contrast with `/altinn-tilganger` which returns 401.
+
+4. **Unknown Altinn fields ignored** — stub the resource document with extra
+   unknown fields and verify deserialization does not throw.
+
+5. **Access package extraction** — add a stub with
+   `type = "urn:altinn:accesspackage"` (e.g.
+   `value = "regnskapsforer-lonn"`) and assert it flows into
+   `grantedByAccessPackages` (not `grantedByRoles`) with the raw `value`.
+   Also assert the response never contains the string `"urn:altinn:"` — we
+   only expose stripped ids.
+
+6. **Determinism** — call twice, assert byte-equal JSON output.
+
+7. **Unit test** for `buildResourceMetadataResponse` covering the
+   missing-metadata-for-resource branch.
+
+8. **Swagger hidden** — assert `/resource-metadata` does NOT appear in
+   [src/main/resources/openapi.yaml](src/main/resources/openapi.yaml)
+   (simple grep-style test) so a future contributor cannot accidentally
+   document it.
+
+## Out of scope
+
+- Localization negotiation (`Accept-Language`). We return all three locales.
+- Pagination / filtering. The full known-resources map is small (~30 items).
+- Rate limiting. The endpoint is O(1) after warmup and reads from memory.
+- Exposing resource-registry fields beyond the ones listed in
+  `ResourceRegistryResource`. If a consumer needs more, add them explicitly.

--- a/src/main/kotlin/no/nav/fager/Application.kt
+++ b/src/main/kotlin/no/nav/fager/Application.kt
@@ -61,6 +61,7 @@ import no.nav.fager.altinn.Altinn2Config
 import no.nav.fager.altinn.Altinn3ClientImpl
 import no.nav.fager.altinn.Altinn3Config
 import no.nav.fager.altinn.AltinnService
+import no.nav.fager.altinn.buildResourceMetadataResponse
 import no.nav.fager.altinn.ResourceRegistry
 import no.nav.fager.infrastruktur.AutentisertM2MPrincipal
 import no.nav.fager.infrastruktur.Health
@@ -272,6 +273,17 @@ fun Application.ktorConfig(
             call.respondRedirect("/swagger-ui")
         }
         swaggerUI(path = "swagger-ui", swaggerFile = "openapi.yaml")
+
+        route("resource-metadata") {
+            get {
+                call.respond(
+                    buildResourceMetadataResponse(
+                        metadata = resourceRegistry.getResourceMetadata(),
+                        policySubjects = resourceRegistry.getPolicySubjects(),
+                    )
+                )
+            }
+        }
 
         route("/m2m") {
             install(TexasAuth) {

--- a/src/main/kotlin/no/nav/fager/altinn/Altinn3Client.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/Altinn3Client.kt
@@ -40,6 +40,7 @@ class Altinn3Config(
 interface Altinn3Client {
     suspend fun resourceOwner_AuthorizedParties(fnr: String): Result<List<AuthorizedParty>>
     suspend fun resourceRegistry_PolicySubjects(resourceId: String): Result<List<PolicySubject>>
+    suspend fun resourceRegistry_Resource(resourceId: String): Result<ResourceRegistryResource>
 }
 
 
@@ -134,6 +135,19 @@ class Altinn3ClientImpl(
 
         httpResponse.body<PolicySubjectResponseWrapper>().data
     }
+
+    override suspend fun resourceRegistry_Resource(resourceId: String) = runCatching {
+        val httpResponse = resourceRegistryClient.get {
+            url {
+                takeFrom(altinn3Config.baseUrl)
+                appendPathSegments("/resourceregistry/api/v1/resource/$resourceId")
+            }
+            accept(ContentType.Application.Json)
+            contentType(ContentType.Application.Json)
+        }
+
+        httpResponse.body<ResourceRegistryResource>()
+    }
 }
 
 @Serializable
@@ -164,5 +178,22 @@ data class AuthorizedParty(
     val authorizedAccessPackagesAsUrn: Set<String>
         get() = authorizedAccessPackages.map { "urn:altinn:accesspackage:$it" }.toSet()
 }
+
+@Serializable
+data class LocalizedText(
+    val nb: String? = null,
+    val nn: String? = null,
+    val en: String? = null,
+)
+
+@Serializable
+data class ResourceRegistryResource(
+    val identifier: String,
+    val title: LocalizedText = LocalizedText(),
+    val rightDescription: LocalizedText = LocalizedText(),
+    val resourceType: String? = null,
+    val status: String? = null,
+    val delegable: Boolean? = null,
+)
 
 

--- a/src/main/kotlin/no/nav/fager/altinn/ResourceMetadataApi.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/ResourceMetadataApi.kt
@@ -1,0 +1,61 @@
+package no.nav.fager.altinn
+
+import kotlinx.serialization.Serializable
+import no.nav.fager.infrastruktur.logger
+import org.slf4j.LoggerFactory
+
+@Serializable
+data class ResourceMetadataResponse(
+    val resources: Map<String, ResourceMetadataEntry>,
+)
+
+@Serializable
+data class ResourceMetadataEntry(
+    val metadata: ResourceRegistryResource,
+    val grantedByRoles: List<String>,
+    val grantedByAccessPackages: List<String>,
+)
+
+private val log = LoggerFactory.getLogger("no.nav.fager.altinn.ResourceMetadataApi")
+
+fun buildResourceMetadataResponse(
+    metadata: Map<ResourceId, ResourceRegistryResource?>,
+    policySubjects: Map<ResourceId, List<PolicySubject>>,
+): ResourceMetadataResponse {
+    val resources = linkedMapOf<String, ResourceMetadataEntry>()
+
+    for (resource in KnownResources) {
+        val resourceId = resource.resourceId
+        if (resources.containsKey(resourceId)) continue
+
+        val resourceMetadata = metadata[resourceId]
+        if (resourceMetadata == null) {
+            log.error("Missing resource metadata for $resourceId")
+            throw IllegalStateException("Missing resource metadata for $resourceId")
+        }
+
+        val subjects = policySubjects[resourceId] ?: emptyList()
+
+        val roles = subjects
+            .filter { it.type == "urn:altinn:rolecode" }
+            .map { it.value }
+            .distinct()
+            .sorted()
+
+        val accessPackages = subjects
+            .filter { it.type == "urn:altinn:accesspackage" }
+            .map { it.value }
+            .distinct()
+            .sorted()
+
+        resources[resourceId] = ResourceMetadataEntry(
+            metadata = resourceMetadata,
+            grantedByRoles = roles,
+            grantedByAccessPackages = accessPackages,
+        )
+    }
+
+    return ResourceMetadataResponse(resources = resources)
+}
+
+

--- a/src/main/kotlin/no/nav/fager/altinn/ResourceRegistry.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/ResourceRegistry.kt
@@ -201,9 +201,12 @@ class ResourceRegistry(
     private val log = logger()
 
     @Volatile
-    private var isReady = false
+    private var policySubjectsReady = false
 
-    override fun isReady() = isReady
+    @Volatile
+    private var resourceMetadataReady = false
+
+    override fun isReady() = policySubjectsReady && resourceMetadataReady
 
     val cacheTTL = 30.minutes
     val cacheRefreshInterval = cacheTTL / 3
@@ -215,8 +218,19 @@ class ResourceRegistry(
         cacheTTL = cacheTTL.toJavaDuration()
     )
 
+    private val resourceMetadataCache = RedisLoadingCache(
+        metricsName = "resource-registry-resource",
+        redisClient = redisConfig.createClient<ResourceRegistryResource>("resource-registry-resource-v1"),
+        loader = { s -> altinn3Client.resourceRegistry_Resource(s).getOrThrow() },
+        cacheTTL = cacheTTL.toJavaDuration()
+    )
+
     private val policySubjectsPerResourceId = AtomicReference(
         KnownResources.associate { it.resourceId to emptyList<PolicySubject>() }
+    )
+
+    private val resourceMetadataPerResourceId = AtomicReference(
+        KnownResources.associate { it.resourceId to null as ResourceRegistryResource? }
     )
 
     val resourceIdToAltinn2Tjeneste: Map<ResourceId, List<Altinn2Tjeneste>> = KnownResources.associate { resource ->
@@ -225,13 +239,23 @@ class ResourceRegistry(
 
     init {
         backgroundCoroutineScope?.launch {
-            while (!isReady && !Health.terminating) {
-                isReady = updatePolicySubjectsForKnownResources { resourceId ->
+            while (!policySubjectsReady && !Health.terminating) {
+                policySubjectsReady = updatePolicySubjectsForKnownResources { resourceId ->
                     this@ResourceRegistry.cache.get(resourceId)
                 }
                 delay(100)
             }
-            log.info("ResourceRegistry isReady policySubjectsPerResourceId=${policySubjectsPerResourceId.get()}")
+            log.info("ResourceRegistry policySubjectsReady policySubjectsPerResourceId=${policySubjectsPerResourceId.get()}")
+        }
+
+        backgroundCoroutineScope?.launch {
+            while (!resourceMetadataReady && !Health.terminating) {
+                resourceMetadataReady = updateResourceMetadataForKnownResources { resourceId ->
+                    this@ResourceRegistry.resourceMetadataCache.get(resourceId)
+                }
+                delay(100)
+            }
+            log.info("ResourceRegistry resourceMetadataReady")
         }
 
         backgroundCoroutineScope?.launch {
@@ -246,12 +270,31 @@ class ResourceRegistry(
                 }
             }
         }
+
+        backgroundCoroutineScope?.launch {
+            while (!Health.terminating) {
+                val success = updateResourceMetadataForKnownResources { resourceId -> resourceMetadataCache.update(resourceId) }
+                if (success) {
+                    log.info("Resource metadata for kjente ressurser oppdatert")
+                    delay(cacheRefreshInterval)
+                } else {
+                    log.error("Kunne ikke oppdatere resource metadata for kjente ressurser. Prøver igjen fortløpende")
+                    delay(5.seconds)
+                }
+            }
+        }
     }
 
     fun getResourceIdForPolicySubject(urn: PolicySubjectUrn): List<ResourceId> =
         policySubjectsPerResourceId.get().filter { (_, policySubjects) ->
             policySubjects.any { it.urn == urn }
         }.map { it.key }
+
+    fun getPolicySubjects(): Map<ResourceId, List<PolicySubject>> =
+        policySubjectsPerResourceId.get()
+
+    fun getResourceMetadata(): Map<ResourceId, ResourceRegistryResource?> =
+        resourceMetadataPerResourceId.get()
 
     suspend fun updatePolicySubjectsForKnownResources(
         fetcher: suspend ResourceRegistry.(resourceId: ResourceId) -> List<PolicySubject>
@@ -273,6 +316,31 @@ class ResourceRegistry(
         } else {
             policySubjectsPerResourceId.set(
                 results.mapValues { (_, res) -> res.getOrThrow().toList() } // immutable copy
+            )
+            true
+        }
+    }
+
+    suspend fun updateResourceMetadataForKnownResources(
+        fetcher: suspend ResourceRegistry.(resourceId: ResourceId) -> ResourceRegistryResource
+    ): Boolean {
+        val results: Map<ResourceId, Result<ResourceRegistryResource>> =
+            KnownResources.associate { res ->
+                val rid = res.resourceId
+                rid to retryWithBackoff { fetcher(rid) }
+            }
+
+        val failures = results.filterValues { it.isFailure }
+        return if (failures.isNotEmpty()) {
+            failures.forEach { (rid, res) ->
+                res.exceptionOrNull()?.let { e ->
+                    log.error("Feil ved henting av resource metadata for $rid", e)
+                }
+            }
+            false
+        } else {
+            resourceMetadataPerResourceId.set(
+                results.mapValues { (_, res) -> res.getOrThrow() }
             )
             true
         }

--- a/src/test/kotlin/no/nav/fager/ResourceMetadataTest.kt
+++ b/src/test/kotlin/no/nav/fager/ResourceMetadataTest.kt
@@ -8,19 +8,19 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import no.nav.fager.altinn.KnownResourceIds
-import no.nav.fager.altinn.ResourceMetadataResponse
-import no.nav.fager.altinn.buildResourceMetadataResponse
 import no.nav.fager.altinn.PolicySubject
+import no.nav.fager.altinn.ResourceMetadataResponse
 import no.nav.fager.altinn.ResourceRegistryResource
+import no.nav.fager.altinn.buildResourceMetadataResponse
 import no.nav.fager.fakes.testWithFakeApplication
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertFailsWith
 
 class ResourceMetadataTest {
 
@@ -114,25 +114,22 @@ class ResourceMetadataTest {
     fun `resource-metadata response shape matches expected JSON`() = testWithFakeApplication {
         val responseText = client.get("/resource-metadata").bodyAsText()
 
-        val permitteringId = "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
-        val sosialtjenesterId = "nav_sosialtjenester_digisos-avtale"
-
         //language=json
         val expected = """
         {
           "resources": {
-            "$permitteringId": {
+            "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger": {
               "metadata": {
-                "identifier": "$permitteringId",
+                "identifier": "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
                 "title": {
-                  "nb": "Tittel for $permitteringId",
-                  "nn": "Tittel nn for $permitteringId",
-                  "en": "Title for $permitteringId"
+                  "nb": "Tittel for nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                  "nn": "Tittel nn for nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                  "en": "Title for nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
                 },
                 "rightDescription": {
-                  "nb": "Rettighet for $permitteringId",
-                  "nn": "Rettighet nn for $permitteringId",
-                  "en": "Right for $permitteringId"
+                  "nb": "Rettighet for nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                  "nn": "Rettighet nn for nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                  "en": "Right for nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
                 },
                 "resourceType": "GenericAccessResource",
                 "status": "Completed",
@@ -141,18 +138,18 @@ class ResourceMetadataTest {
               "grantedByRoles": ["dagl", "lede"],
               "grantedByAccessPackages": ["regnskapsforer-lonn"]
             },
-            "$sosialtjenesterId": {
+            "nav_sosialtjenester_digisos-avtale": {
               "metadata": {
-                "identifier": "$sosialtjenesterId",
+                "identifier": "nav_sosialtjenester_digisos-avtale",
                 "title": {
-                  "nb": "Tittel for $sosialtjenesterId",
-                  "nn": "Tittel nn for $sosialtjenesterId",
-                  "en": "Title for $sosialtjenesterId"
+                  "nb": "Tittel for nav_sosialtjenester_digisos-avtale",
+                  "nn": "Tittel nn for nav_sosialtjenester_digisos-avtale",
+                  "en": "Title for nav_sosialtjenester_digisos-avtale"
                 },
                 "rightDescription": {
-                  "nb": "Rettighet for $sosialtjenesterId",
-                  "nn": "Rettighet nn for $sosialtjenesterId",
-                  "en": "Right for $sosialtjenesterId"
+                  "nb": "Rettighet for nav_sosialtjenester_digisos-avtale",
+                  "nn": "Rettighet nn for nav_sosialtjenester_digisos-avtale",
+                  "en": "Right for nav_sosialtjenester_digisos-avtale"
                 },
                 "resourceType": "GenericAccessResource",
                 "status": "Completed",

--- a/src/test/kotlin/no/nav/fager/ResourceMetadataTest.kt
+++ b/src/test/kotlin/no/nav/fager/ResourceMetadataTest.kt
@@ -13,6 +13,8 @@ import no.nav.fager.altinn.buildResourceMetadataResponse
 import no.nav.fager.altinn.PolicySubject
 import no.nav.fager.altinn.ResourceRegistryResource
 import no.nav.fager.fakes.testWithFakeApplication
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -107,6 +109,66 @@ class ResourceMetadataTest {
         }
         assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
+
+    @Test
+    fun `resource-metadata response shape matches expected JSON`() = testWithFakeApplication {
+        val responseText = client.get("/resource-metadata").bodyAsText()
+
+        val permitteringId = "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
+        val sosialtjenesterId = "nav_sosialtjenester_digisos-avtale"
+
+        //language=json
+        val expected = """
+        {
+          "resources": {
+            "$permitteringId": {
+              "metadata": {
+                "identifier": "$permitteringId",
+                "title": {
+                  "nb": "Tittel for $permitteringId",
+                  "nn": "Tittel nn for $permitteringId",
+                  "en": "Title for $permitteringId"
+                },
+                "rightDescription": {
+                  "nb": "Rettighet for $permitteringId",
+                  "nn": "Rettighet nn for $permitteringId",
+                  "en": "Right for $permitteringId"
+                },
+                "resourceType": "GenericAccessResource",
+                "status": "Completed",
+                "delegable": true
+              },
+              "grantedByRoles": ["dagl", "lede"],
+              "grantedByAccessPackages": ["regnskapsforer-lonn"]
+            },
+            "$sosialtjenesterId": {
+              "metadata": {
+                "identifier": "$sosialtjenesterId",
+                "title": {
+                  "nb": "Tittel for $sosialtjenesterId",
+                  "nn": "Tittel nn for $sosialtjenesterId",
+                  "en": "Title for $sosialtjenesterId"
+                },
+                "rightDescription": {
+                  "nb": "Rettighet for $sosialtjenesterId",
+                  "nn": "Rettighet nn for $sosialtjenesterId",
+                  "en": "Right for $sosialtjenesterId"
+                },
+                "resourceType": "GenericAccessResource",
+                "status": "Completed",
+                "delegable": true
+              },
+              "grantedByRoles": [],
+              "grantedByAccessPackages": []
+            }
+          }
+        }
+        """.trimIndent()
+
+        JSONAssert.assertEquals(expected, responseText, JSONCompareMode.LENIENT)
+    }
 }
+
+
 
 

--- a/src/test/kotlin/no/nav/fager/ResourceMetadataTest.kt
+++ b/src/test/kotlin/no/nav/fager/ResourceMetadataTest.kt
@@ -1,0 +1,112 @@
+package no.nav.fager
+
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import no.nav.fager.altinn.KnownResourceIds
+import no.nav.fager.altinn.ResourceMetadataResponse
+import no.nav.fager.altinn.buildResourceMetadataResponse
+import no.nav.fager.altinn.PolicySubject
+import no.nav.fager.altinn.ResourceRegistryResource
+import no.nav.fager.fakes.testWithFakeApplication
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertFailsWith
+
+class ResourceMetadataTest {
+
+    @Test
+    fun `GET resource-metadata returns 200 with all known resources`() = testWithFakeApplication {
+        val response = client.get("/resource-metadata")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.body<ResourceMetadataResponse>()
+        // every known resource id should be present
+        KnownResourceIds.distinct().forEach { resourceId ->
+            assertNotNull(body.resources[resourceId], "Missing resource: $resourceId")
+        }
+    }
+
+    @Test
+    fun `GET resource-metadata requires no authentication`() = testWithFakeApplication {
+        // No Authorization header
+        val response = client.get("/resource-metadata")
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `resource-metadata passes through metadata fields`() = testWithFakeApplication {
+        val body = client.get("/resource-metadata").body<ResourceMetadataResponse>()
+
+        val permitteringId = "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
+        val entry = body.resources[permitteringId]!!
+        assertEquals(permitteringId, entry.metadata.identifier)
+        assertNotNull(entry.metadata.title.nb)
+        assertNotNull(entry.metadata.title.nn)
+        assertNotNull(entry.metadata.title.en)
+        assertEquals("GenericAccessResource", entry.metadata.resourceType)
+        assertEquals("Completed", entry.metadata.status)
+        assertEquals(true, entry.metadata.delegable)
+    }
+
+    @Test
+    fun `resource-metadata extracts roles and access packages correctly`() = testWithFakeApplication {
+        val body = client.get("/resource-metadata").body<ResourceMetadataResponse>()
+
+        val permitteringId = "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
+        val entry = body.resources[permitteringId]!!
+
+        // roles extracted and sorted
+        assertEquals(listOf("dagl", "lede"), entry.grantedByRoles)
+
+        // access packages extracted
+        assertEquals(listOf("regnskapsforer-lonn"), entry.grantedByAccessPackages)
+    }
+
+    @Test
+    fun `resource-metadata never contains urn prefix in response`() = testWithFakeApplication {
+        val responseText = client.get("/resource-metadata").bodyAsText()
+        assertFalse(responseText.contains("urn:altinn:"), "Response should not contain 'urn:altinn:' prefix")
+    }
+
+    @Test
+    fun `resource-metadata is deterministic`() = testWithFakeApplication {
+        val response1 = client.get("/resource-metadata").bodyAsText()
+        val response2 = client.get("/resource-metadata").bodyAsText()
+        assertEquals(response1, response2, "Response should be deterministic across calls")
+    }
+
+    @Test
+    fun `buildResourceMetadataResponse fails on missing metadata`() {
+        val metadata = mapOf("some-resource" to null as ResourceRegistryResource?)
+        val policySubjects = mapOf("some-resource" to emptyList<PolicySubject>())
+
+        assertFailsWith<IllegalStateException> {
+            buildResourceMetadataResponse(metadata, policySubjects)
+        }
+    }
+
+    @Test
+    fun `resource-metadata is not in openapi yaml`() {
+        val openapiContent = File("src/main/resources/openapi.yaml").readText()
+        assertFalse(openapiContent.contains("resource-metadata"), "resource-metadata should not appear in openapi.yaml")
+    }
+
+    @Test
+    fun `altinn-tilganger still requires auth`() = testWithFakeApplication {
+        // No Authorization header for altinn-tilganger should fail
+        val response = client.post("/altinn-tilganger") {
+            contentType(ContentType.Application.Json)
+        }
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+}
+
+

--- a/src/test/kotlin/no/nav/fager/fakes/FakeApplication.kt
+++ b/src/test/kotlin/no/nav/fager/fakes/FakeApplication.kt
@@ -47,7 +47,7 @@ class FakeApplication(
 
     private val fakeAltinn3Api = FakeApi().also {
         KnownResourceIds.forEach { resourceId ->
-            val response = when (resourceId) {
+            val policySubjectsResponse = when (resourceId) {
                 "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" ->
                     //language=json
                     """
@@ -63,6 +63,11 @@ class FakeApplication(
                           "type": "urn:altinn:rolecode",
                           "value": "lede",
                           "urn": "urn:altinn:rolecode:lede"
+                        },
+                        {
+                          "type": "urn:altinn:accesspackage",
+                          "value": "regnskapsforer-lonn",
+                          "urn": "urn:altinn:accesspackage:regnskapsforer-lonn"
                         }
                       ]
                     }
@@ -73,7 +78,32 @@ class FakeApplication(
                     """{ "links": {}, "data": [] }"""
             }
             it.stubs[Get to "/resourceregistry/api/v1/resource/${resourceId}/policy/subjects"] = {
-                call.respondText(response, ContentType.Application.Json)
+                call.respondText(policySubjectsResponse, ContentType.Application.Json)
+            }
+
+            val resourceDocResponse =
+                //language=json
+                """
+                {
+                  "identifier": "$resourceId",
+                  "title": {
+                    "nb": "Tittel for $resourceId",
+                    "nn": "Tittel nn for $resourceId",
+                    "en": "Title for $resourceId"
+                  },
+                  "rightDescription": {
+                    "nb": "Rettighet for $resourceId",
+                    "nn": "Rettighet nn for $resourceId",
+                    "en": "Right for $resourceId"
+                  },
+                  "resourceType": "GenericAccessResource",
+                  "status": "Completed",
+                  "delegable": true,
+                  "someUnknownField": "should be ignored"
+                }
+                """.trimIndent()
+            it.stubs[Get to "/resourceregistry/api/v1/resource/$resourceId"] = {
+                call.respondText(resourceDocResponse, ContentType.Application.Json)
             }
         }
     }

--- a/src/test/kotlin/no/nav/fager/fakes/clients/FakeAltinn3Client.kt
+++ b/src/test/kotlin/no/nav/fager/fakes/clients/FakeAltinn3Client.kt
@@ -3,11 +3,16 @@ package no.nav.fager.fakes.clients
 import no.nav.fager.altinn.Altinn3Client
 import no.nav.fager.altinn.AuthorizedParty
 import no.nav.fager.altinn.PolicySubject
+import no.nav.fager.altinn.ResourceRegistryResource
+import no.nav.fager.altinn.LocalizedText
 import no.nav.fager.fakes.FakeClientBase
 
 class FakeAltinn3Client(
     private val resourceOwner_AuthorizedPartiesHandler: () -> List<AuthorizedParty> = { listOf() },
     private val resourceRegistry_PolicySubjectsHandler: (resourceId: String) -> List<PolicySubject> = { listOf() },
+    private val resourceRegistry_ResourceHandler: (resourceId: String) -> ResourceRegistryResource = { resourceId ->
+        ResourceRegistryResource(identifier = resourceId)
+    },
 ) : Altinn3Client, FakeClientBase() {
 
     override suspend fun resourceOwner_AuthorizedParties(fnr: String): Result<List<AuthorizedParty>> {
@@ -18,5 +23,10 @@ class FakeAltinn3Client(
     override suspend fun resourceRegistry_PolicySubjects(resourceId: String): Result<List<PolicySubject>> {
         addFunctionCall(this::resourceRegistry_PolicySubjects.name, resourceId)
         return Result.success(resourceRegistry_PolicySubjectsHandler(resourceId))
+    }
+
+    override suspend fun resourceRegistry_Resource(resourceId: String): Result<ResourceRegistryResource> {
+        addFunctionCall(this::resourceRegistry_Resource.name, resourceId)
+        return Result.success(resourceRegistry_ResourceHandler(resourceId))
     }
 }


### PR DESCRIPTION
Add a new unauthenticated GET /resource-metadata endpoint that returns metadata and policy subject information for all known Altinn resources. The endpoint serves a pre-computed snapshot from in-memory caches, requiring no outbound HTTP calls on the request path. It is intended as a public listing of NAV resources for consumer teams. Implementation:
- Add resourceRegistry_Resource() to Altinn3Client for fetching resource documents from Altinn Resource Registry
- Add LocalizedText and ResourceRegistryResource DTOs with kotlinx.serialization, tolerant of unknown Altinn fields
- Extend ResourceRegistry with a second RedisLoadingCache and AtomicReference for resource metadata, with independent warmup and refresh loops
- Gate readiness on both policy subjects AND resource metadata being warmed
- Expose getPolicySubjects() and getResourceMetadata() accessors
- Add buildResourceMetadataResponse() builder that iterates KnownResources in declaration order, extracts grantedByRoles and grantedByAccessPackages from policy subjects (sorted, de-duplicated, stripped of URN prefixes)
- Wire route outside auth-protected blocks in Application.kt
- Intentionally omit from openapi.yaml (hidden by design) Tests:
- Extend FakeApplication stubs with resource document responses and access package policy subjects
- Add ResourceMetadataTest with 9 tests covering happy path, no-auth access, metadata pass-through, role/access-package extraction, URN exclusion, determinism, error handling, OpenAPI exclusion, and auth contrast
Co-authored-by: GitHub Copilot <noreply@github.com>