### PR TITLE
Fjern filtreringslogikk hvor tomme foreldre også fjernes

### DIFF
--- a/src/main/kotlin/no/nav/fager/altinn/AltinnService.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/AltinnService.kt
@@ -157,25 +157,12 @@ class AltinnService(
 
 /**
  * Filtrerer rekursivt basert på angitt filter.
- * Her antas det at vi kun skal filtrere på løvnoder (virksomheter) og ikke på overenheter.
- * Dvs. at vi ikke forventer at en tjeneste kun er delegert på et overordnet nivå.
- * Oss bekjent gjør Nav tilgangsstyring på virksomheter og ikke på overordnet nivå.
- * Vi har ikke observert tilfeller i dev hvor en parent har tilgang som ikke finnes blant underenhetene,
- * men det betyr ikke at det ikke forekommer.
- *
- * Mao. vi filtrerer fra bunnen. Dersom en overordnet enhet har barn og alle disse fjernes pga filteret
- * så fjernes også overordnet enhet. Dette uavhengig om overordnet enhet har tilgangen definert eller ikke.
  */
 private fun List<AltinnTilgang>.filterRecursive(filter: Filter): List<AltinnTilgang> =
     mapNotNull { tilgang ->
         if (!filter.inkluderSlettede && tilgang.erSlettet) return@mapNotNull null
 
         val filtrerteUnderenheter = tilgang.underenheter.filterRecursive(filter)
-
-        val haddeUnderenheter = tilgang.underenheter.isNotEmpty()
-        val alleUnderenheterFjernet = haddeUnderenheter && filtrerteUnderenheter.isEmpty()
-        if (alleUnderenheterFjernet) return@mapNotNull null
-
         tilgang.copy(underenheter = filtrerteUnderenheter)
     }.filter { tilgang ->
         if (filter.isEmpty) return@filter true

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -397,16 +397,6 @@ components:
         Her antas det at overordnede enhet ikke har tilganger som ikke er
         delegert til en av sine underenheter.
 
-        Logikken er nå slik at dersom en parent har tjenesten, men ingen av
-        underenhetene har den så vil parenten også fjernes.
-
-        Dette er for å hindre at en overordnet enhet blir til laveste nivå.
-
-        Dette er en antakelse vi har gjort basert på observasjoner i dev. 
-
-        Dersom det viser seg at tjenester delegeres ekspisitt på overordnet nivå
-        og det er noe dere trenger at vi støtter ta kontakt med oss. 
-
     no.nav.fager.AltinnTilgangerM2MRequest:
       title: AltinnTilgangerM2MRequest
       required:

--- a/src/test/kotlin/no/nav/fager/AltinnTilgangerResultatTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnTilgangerResultatTest.kt
@@ -134,50 +134,6 @@ class AltinnTilgangerResultatTest {
     }
 
     @Test
-    fun `filter fjerner tom parent dersom alle underenheter filtreres bort, tross for filter match på parent`() {
-        AltinnTilgangerResultat(
-            isError = false,
-            altinnTilganger = listOf(
-                AltinnTilgang(
-                    orgnr = "1",
-                    altinn3Tilganger = setOf("nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"),
-                    altinn2Tilganger = setOf("4936:1"),
-                    underenheter = listOf(
-                        AltinnTilgang(
-                            orgnr = "2",
-                            altinn3Tilganger = setOf("foo"),
-                            altinn2Tilganger = setOf("bar:none"),
-                            underenheter = listOf(),
-                            navn = "2",
-                            organisasjonsform = "BEDR",
-                            erSlettet = false
-                        ),
-                        AltinnTilgang(
-                            orgnr = "3",
-                            altinn3Tilganger = setOf("foo"),
-                            altinn2Tilganger = setOf("bar:none"),
-                            underenheter = listOf(),
-                            navn = "3",
-                            organisasjonsform = "BEDR",
-                            erSlettet = false
-                        )
-                    ),
-                    navn = "1",
-                    organisasjonsform = "AS",
-                    erSlettet = false
-                )
-            )
-        ).filter(
-            Filter(
-                altinn2Tilganger = setOf("4936:1"),
-                altinn3Tilganger = setOf()
-            )
-        ).let {
-            assertEquals(0, it.altinnTilganger.size)
-        }
-    }
-
-    @Test
     fun `Filter on sample from dev works as expected`() {
         val sample = Json.decodeFromString<AltinnTilgangerResultat>(sampleJSON)
 

--- a/src/test/kotlin/no/nav/fager/AltinnTilgangerTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnTilgangerTest.kt
@@ -1344,4 +1344,98 @@ class AltinnTilgangerTest {
             assertEquals(HttpStatusCode.OK, status)
         }.body<AltinnTilgangerResponse>().also(assertResponse)
     }
+
+    @Test
+    fun `KOMM med kun slettede underenheter returneres uten underenheter`() = testWithFakeApplication { app ->
+        app.altinn3Response(Post, "/accessmanagement/api/v1/resourceowner/authorizedparties") {
+            call.respondText(
+                //language=json
+                """
+                [
+                  {
+                    "partyUuid": "b2c942df-d8c8-5f6f-aa21-3be0b06c5fc2",
+                    "name": "KOMMUNEANSEN",
+                    "organizationNumber": "820000001",
+                    "personId": null,
+                    "partyId": 50100001,
+                    "type": "Organization",
+                    "unitType": "KOMM",
+                    "isDeleted": false,
+                    "onlyHierarchyElementWithNoAccess": false,
+                    "authorizedResources": ["test-fager"],
+                    "authorizedRoles": [],
+                    "authorizedAccessPackages": [],
+                    "subunits": [
+                      {
+                        "partyUuid": "c3ea53e0-e9d9-6070-bb32-4cf1c17d6ed3",
+                        "name": "SLETTET ENHET 1",
+                        "organizationNumber": "920000002",
+                        "personId": null,
+                        "partyId": 50100002,
+                        "type": "Organization",
+                        "unitType": "BEDR",
+                        "isDeleted": true,
+                        "onlyHierarchyElementWithNoAccess": false,
+                        "authorizedResources": ["test-fager"],
+                        "authorizedRoles": [],
+                        "authorizedAccessPackages": [],
+                        "subunits": []
+                      },
+                      {
+                        "partyUuid": "d4fb64f1-faea-7181-cc43-5d02d28e7fe4",
+                        "name": "SLETTET ENHET 2",
+                        "organizationNumber": "920000003",
+                        "personId": null,
+                        "partyId": 50100003,
+                        "type": "Organization",
+                        "unitType": "BEDR",
+                        "isDeleted": true,
+                        "onlyHierarchyElementWithNoAccess": false,
+                        "authorizedResources": ["test-fager"],
+                        "authorizedRoles": [],
+                        "authorizedAccessPackages": [],
+                        "subunits": []
+                      }
+                    ]
+                  }
+                ]
+                """.trimIndent(), ContentType.Application.Json
+            )
+        }
+        app.altinn2Response(Get, "/api/serviceowner/reportees") {
+            call.respondText("[]", ContentType.Application.Json)
+        }
+
+        val assertResponse: (AltinnTilgangerResponse) -> Unit = {
+            assertFalse(it.isError)
+            assertEquals(1, it.hierarki.size)
+            assertEquals("820000001", it.hierarki[0].orgnr)
+            assertEquals("KOMMUNEANSEN", it.hierarki[0].navn)
+            assertEquals("KOMM", it.hierarki[0].organisasjonsform)
+            assertEquals(emptyList(), it.hierarki[0].underenheter)
+        }
+
+        client.post("/altinn-tilganger") {
+            header("Authorization", "Bearer idporten-loa-high:${fnr.next()}")
+            contentType(ContentType.Application.Json)
+            setBody("")
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+        }.body<AltinnTilgangerResponse>().also(assertResponse)
+
+        client.post("/m2m/altinn-tilganger") {
+            header("Authorization", "Bearer fakem2mtoken")
+            contentType(ContentType.Application.Json)
+            setBody(
+                //language=json
+                """
+                {
+                    "fnr": "${fnr.next()}"
+                }
+                """.trimIndent()
+            )
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+        }.body<AltinnTilgangerResponse>().also(assertResponse)
+    }
 }


### PR DESCRIPTION
I Altinn så arves ikke delegeringer via ORGL.
Dette betyr at de fleste kommuner KOMM i Norge som delegerer til KOMM nivå ikke ser sine tilganger, I tillegg så hadde vi logikk som fjernet tomme foreldre etter filtrering, for å unngå at foreldre plutselig ble valgbare. Denne logikken ser ikek ut til å være nødvendig. Men hvis det oppstår så bør det fikses i virksomhetsvelgeren, og ikke i tilgagner.

Med denne endringen så flerner vi 'lur' filtreringslogikk, og viser listen as is fra Altinn.