### PR TITLE
harden texas auth client against upstream IdP outages

### DIFF
--- a/specifications/texas_client_hardening.md
+++ b/specifications/texas_client_hardening.md
@@ -1,0 +1,273 @@
+# Specification: Harden Texas auth client against upstream IdP outages
+
+## Background
+
+On 2026-08-05, ID-porten was hit by a DDoS which cascaded into elevated latency at
+Maskinporten. Trace `2b9c85` (`Trace-2b9c85-2026-08-05 10_20_06.json` at repo root)
+shows a single `POST /altinn-tilganger` taking **13.65 s** end-to-end, all of it
+spent looping on `texas /api/v1/token`:
+
+| Attempt | Offset (ms) | Duration (ms) | Result |
+|--------:|------------:|--------------:|--------|
+| 1 | 97.7  | 1333 | 500 – `Request failed after 3 retries … maskinporten.no/token … operation timed out` |
+| 2 | 1692.4 | 3822 | same |
+| 3 | 5769.0 | 3787 | same |
+| 4 | 9811.0 | 3820 | same |
+
+Two nested retry cycles multiplied each other:
+
+- **Texas → Maskinporten**: 3 retries internal to texas.
+- **arbeidsgiver-altinn-tilganger → Texas**: `retryOnServerErrors(3)` in
+  `defaultHttpClient` (`Http.kt:28`) — 4 attempts total against a texas endpoint
+  that had already exhausted its own retries.
+
+The failure never surfaced:
+
+- `TexasAuthClientPlugin.onRequest` (`Texas.kt:235`) threw a generic `Exception`.
+- `Altinn3ClientImpl.resourceOwner_AuthorizedParties` (`Altinn3Client.kt:80`)
+  wrapped the call in `runCatching { … }`, converting the exception to
+  `Result.failure`.
+- `AltinnService.hentTilgangerFraAltinn` (`AltinnService.kt:57-70`) folded
+  `onFailure = { emptyList() }` — silently returning an empty parties list.
+- The client got HTTP 200 with an empty result. No ERROR log line was written,
+  so no alert fired.
+
+## Scope
+
+Three targeted changes:
+
+1. Add a `customizeRetry` override block to `defaultHttpClient` and use it in
+   `AuthClient` to disable server-error retries against texas.
+2. Install an explicit `HttpTimeout` on the texas `AuthClient` with **request,
+   connect, and socket all set to 1000 ms** ("across the board" = all three
+   timeout values, not all clients). Other `defaultHttpClient` callers are
+   **not** touched.
+3. Emit `log.error(...)` in `AltinnService` when the Altinn call returns
+   `Result.failure`, so the graceful fallback still produces an alertable log
+   line.
+
+Out of scope: alert rules (nais/PrometheusRule), retry-jitter tuning, changes
+to the Altinn 3 client's timeout (`Altinn3Client.kt:66-68` stays at
+`requestTimeoutMillis = 60_000`), changes to texas itself.
+
+## Changes
+
+### 1. `AuthClient` uses a client that overrides the retry policy
+
+Files:
+- `src/main/kotlin/no/nav/fager/infrastruktur/Http.kt`
+- `src/main/kotlin/no/nav/fager/texas/Texas.kt`
+
+Follow the existing `customizeLogging` / `customizeMetrics` pattern in
+`Http.kt`: add a `customizeRetry` block, invoked at the **end** of the
+`HttpRequestRetry` config so callers can override any of the defaults
+(including setting `retryOnServerErrors(0)`):
+
+```kotlin
+fun defaultHttpClient(
+    customizeLogging: LoggingConfig.() -> Unit = { },
+    customizeMetrics: HttpClientMetricsFeature.Config.() -> Unit = {},
+    customizeRetry: HttpRequestRetryConfig.() -> Unit = { },
+    configure: HttpClientConfig<CIOEngineConfig>.() -> Unit = {}
+) = HttpClient(CIO) {
+    expectSuccess = true
+    install(HttpRequestRetry) {
+        retryOnServerErrors(3)
+        retryOnExceptionIf(3) { _, cause -> /* unchanged */ }
+        delayMillis { 250L }
+        customizeRetry()          // ← runs last: callers can override defaults
+    }
+    // ... rest unchanged
+}
+```
+
+Notes on placement:
+
+- `customizeRetry()` is invoked **after** the defaults so a caller passing
+  `retryOnServerErrors(0)` fully overrides the default `retryOnServerErrors(3)`
+  (both call `setter`-style methods on `HttpRequestRetryConfig`; last write
+  wins).
+- The block is positioned between `customizeMetrics` and `configure` to keep
+  the "customize a plugin's config" parameters grouped and `configure` (which
+  operates on the whole `HttpClientConfig`) last.
+- Import: `io.ktor.client.plugins.HttpRequestRetryConfig`.
+
+In `Texas.kt`, change the `AuthClient` default. Retry override goes in
+`customizeRetry`; timeout goes in `configure` (see change 2):
+
+```kotlin
+class AuthClient(
+    private val config: TexasAuthConfig,
+    private val provider: IdentityProvider,
+    private val httpClient: HttpClient = defaultHttpClient(
+        customizeRetry = {
+            retryOnServerErrors(0)
+        }
+    ) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 1_000
+            connectTimeoutMillis = 1_000
+            socketTimeoutMillis  = 1_000
+        }
+    },
+) { /* rest unchanged */ }
+```
+
+Rationale: texas is a local sidecar-style token endpoint that already retries
+against the IdP. When it returns 5xx it has given up; a further client-side
+retry cannot succeed and only multiplies latency (~4× in this trace). Network
+exceptions (`SocketTimeoutException`, `ConnectTimeoutException`, …) remain
+retried via `retryOnExceptionIf(3)` — that path is unchanged.
+
+Choosing `customizeRetry` (a lambda on `HttpRequestRetryConfig`) over a
+scalar `retryOnServerErrors: Int = 3` parameter matches the abstraction level
+already used by `customizeLogging` and `customizeMetrics` in the same
+function, and leaves room for future overrides (`retryOnException`,
+`delayMillis`, `modifyRequest`) without further parameter churn.
+
+### 2. `HttpTimeout` on the texas `AuthClient` — 1000 ms across the board
+
+File: `src/main/kotlin/no/nav/fager/texas/Texas.kt`
+(Import: `io.ktor.client.plugins.HttpTimeout`.)
+
+"Across the board" here means **all three timeout values** are 1000 ms:
+
+```kotlin
+install(HttpTimeout) {
+    requestTimeoutMillis = 1_000
+    connectTimeoutMillis = 1_000
+    socketTimeoutMillis  = 1_000
+}
+```
+
+This is scoped to the texas `AuthClient` only. `defaultHttpClient` itself is
+**not** modified to install `HttpTimeout` globally, and `Altinn3ClientImpl`'s
+existing `install(HttpTimeout) { requestTimeoutMillis = 60_000 }`
+(`Altinn3Client.kt:66-68`) stays as-is.
+
+Ktor `HttpTimeout` interacts with `HttpRequestRetry` as follows:
+`requestTimeoutMillis` is per-attempt. With `retryOnServerErrors = 0` and
+`retryOnExceptionIf(3)` retained, the worst case for a texas call is
+`1 attempt on 5xx` or `up to 4 attempts × 1 s + 3 × 250 ms delay ≈ 4.75 s` if
+each attempt throws a retryable network exception. Under a repeat of the
+2026-08-05 outage (texas returning 500 after ~1.3–3.8 s), the client-side call
+is bounded to a single ~1 s window instead of the observed ~13.5 s.
+
+### 3. `log.error` in `AltinnService.onFailure`
+
+File: `src/main/kotlin/no/nav/fager/altinn/AltinnService.kt`
+
+Currently (`AltinnService.kt:53-70`):
+
+```kotlin
+internal suspend fun hentTilgangerFraAltinn(fnr: String) =
+    timer.coRecord {
+        coroutineScope {
+            val altinn3TilgangerResult = altinn3Client.resourceOwner_AuthorizedParties(fnr)
+            val altinn3Tilganger = altinn3TilgangerResult.fold(
+                onSuccess = { altinn3tilganger -> /* … */ },
+                onFailure = { emptyList() }
+            )
+            // ...
+        }
+    }
+```
+
+Add a `log = logger()` field to the class (alongside the existing `teamLogger`)
+and log the failure with the exception:
+
+```kotlin
+class AltinnService(
+    private val altinn3Client: Altinn3Client,
+    private val redisClient: AltinnTilgangerRedisClient,
+    private val resourceRegistry: ResourceRegistry,
+) {
+    // ...
+    private val log = logger()
+    private val teamLogger = teamLogger()
+    // ...
+
+    internal suspend fun hentTilgangerFraAltinn(fnr: String) =
+        timer.coRecord {
+            coroutineScope {
+                val altinn3TilgangerResult = altinn3Client.resourceOwner_AuthorizedParties(fnr)
+                val altinn3Tilganger = altinn3TilgangerResult.fold(
+                    onSuccess = { altinn3tilganger -> /* unchanged */ },
+                    onFailure = { e ->
+                        log.error("Klarte ikke hente authorizedParties fra Altinn 3", e)
+                        emptyList()
+                    }
+                )
+                // ... rest unchanged
+            }
+        }
+```
+
+Notes:
+
+- Use `logger()` (`Logging.kt:218`), **not** `teamLogger()` — the team logger
+  routes to Elastic/team-logs and is filtered out of the primary log stream
+  used for alerting.
+- The message must **not** contain the `fnr` (PII). The `MaskingAppender` will
+  mask 11-digit sequences, but the compile-time contract is: no user
+  identifiers in the ERROR log line. Only the exception (which contains the
+  upstream URL and cause chain) is safe to log.
+- The graceful fallback (returning `emptyList()` and continuing with
+  `isError = true`) is **preserved**. The behavioural change is: one ERROR log
+  line per failed Altinn 3 call. Alerting can then be driven from the standard
+  ERROR-log alert path.
+
+## Non-goals / explicitly unchanged
+
+- HTTP response body and status of `POST /altinn-tilganger` — still 200 with
+  `isError = true` in the payload when Altinn 3 fails. Callers depend on this.
+- `altinnservice.altinn{result="isError"}` metric — still emitted; no change.
+- `TexasAuthClientPlugin` in `Texas.kt:224-238` — still throws the same generic
+  exception. Logging is added one layer up in `AltinnService` where all texas
+  failure paths converge.
+- `retryOnExceptionIf(3)` — still retries on `SocketTimeoutException`,
+  `ConnectTimeoutException`, `EOFException`, `SSLHandshakeException`,
+  `ClosedReceiveChannelException`. Unchanged.
+- `defaultHttpClient` `delayMillis { 250L }` — unchanged. Exponential
+  backoff/jitter is a separate follow-up.
+- `Altinn3ClientImpl.resourceOwnerClient` `HttpTimeout { requestTimeoutMillis = 60_000 }`
+  — unchanged. Only the texas `AuthClient` gets the 1000 ms timeout.
+- `defaultHttpClient` itself does **not** install `HttpTimeout`. Timeout is
+  configured per-client via the `configure` block.
+
+## Verification
+
+1. `defaultHttpClient(customizeRetry = { retryOnServerErrors(0) })` used by
+   `AuthClient`: unit test that a texas 500 response causes exactly 1 outbound
+   call (no retries) and surfaces as an exception to the caller.
+   `retryOnExceptionIf` must still fire on `SocketTimeoutException` (add or
+   keep an existing test). Add a small direct test on `defaultHttpClient` that
+   `customizeRetry` runs after the defaults (i.e. the override takes effect).
+2. `HttpTimeout` of 1000 ms on the texas `AuthClient`: unit test that a
+   request against a slow stub (>1 s response) throws
+   `HttpRequestTimeoutException`. The Altinn 3 client still has its 60 s
+   `requestTimeoutMillis` — verify a separate test does not regress there.
+3. `log.error` in `AltinnService`: unit test that `hentTilgangerFraAltinn`
+   with a failing `altinn3Client` (e.g. `Result.failure(RuntimeException("boom"))`)
+   writes exactly one ERROR-level log event containing the exception and
+   returns `AltinnTilgangerResultat(isError = true, altinnTilganger = emptyList())`.
+   No `fnr` in the log message.
+4. Existing tests in `AltinnServiceTest.kt`, `AltinnTilgangerTest.kt`,
+   `TexasTest.kt` continue to pass.
+
+## Files touched
+
+- `src/main/kotlin/no/nav/fager/infrastruktur/Http.kt` — add
+  `customizeRetry: HttpRequestRetryConfig.() -> Unit = { }` parameter to
+  `defaultHttpClient`; invoke it at the end of the `install(HttpRequestRetry)`
+  block. Add `io.ktor.client.plugins.HttpRequestRetryConfig` import. No other
+  changes.
+- `src/main/kotlin/no/nav/fager/texas/Texas.kt` — change `AuthClient` default
+  `httpClient` to
+  `defaultHttpClient(customizeRetry = { retryOnServerErrors(0) }) { install(HttpTimeout) { requestTimeoutMillis = 1_000; connectTimeoutMillis = 1_000; socketTimeoutMillis = 1_000 } }`.
+  Add `io.ktor.client.plugins.HttpTimeout` import.
+- `src/main/kotlin/no/nav/fager/altinn/AltinnService.kt` — add `log = logger()`
+  field; replace `onFailure = { emptyList() }` with
+  `onFailure = { e -> log.error("Klarte ikke hente authorizedParties fra Altinn 3", e); emptyList() }`.
+- `src/test/kotlin/no/nav/fager/…` — add/adjust tests per "Verification"
+  above.

--- a/src/main/kotlin/no/nav/fager/altinn/AltinnService.kt
+++ b/src/main/kotlin/no/nav/fager/altinn/AltinnService.kt
@@ -8,6 +8,7 @@ import no.nav.fager.AltinnTilgang
 import no.nav.fager.Filter
 import no.nav.fager.infrastruktur.Metrics
 import no.nav.fager.infrastruktur.coRecord
+import no.nav.fager.infrastruktur.logger
 import no.nav.fager.infrastruktur.teamLogger
 import no.nav.fager.redis.AltinnTilgangerRedisClient
 
@@ -25,6 +26,7 @@ class AltinnService(
     private val timer = Metrics.meterRegistry.timer("altinnservice.hentTilgangerFraAltinn")
     private val cacheCount = Metrics.counter("altinnservice.cache")
     private val altinnCount = Metrics.counter("altinnservice.altinn")
+    private val log = logger()
     private val teamLogger = teamLogger()
 
     suspend fun hentTilganger(
@@ -66,7 +68,10 @@ class AltinnService(
                             }).toSet()
                         }
                     },
-                    onFailure = { emptyList() }
+                    onFailure = { e ->
+                        log.error("Klarte ikke hente authorizedParties fra Altinn 3", e)
+                        emptyList()
+                    }
                 )
 
                 val orgnrTilAltinn2Mapped = altinn3Tilganger.flatMap {

--- a/src/main/kotlin/no/nav/fager/infrastruktur/Http.kt
+++ b/src/main/kotlin/no/nav/fager/infrastruktur/Http.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.cio.CIOEngineConfig
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpRequestRetryConfig
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.LoggingConfig
@@ -21,9 +22,11 @@ import javax.net.ssl.SSLHandshakeException
 fun defaultHttpClient(
     customizeLogging: LoggingConfig.() -> Unit = { },
     customizeMetrics: HttpClientMetricsFeature.Config.() -> Unit = {},
+    customizeRetry: HttpRequestRetryConfig.() -> Unit = { },
     configure: HttpClientConfig<CIOEngineConfig>.() -> Unit = {}
 ) = HttpClient(CIO) {
     expectSuccess = true
+
     install(HttpRequestRetry) {
         retryOnServerErrors(3)
         retryOnExceptionIf(3) { _, cause ->
@@ -40,6 +43,8 @@ fun defaultHttpClient(
         }
 
         delayMillis { 250L }
+
+        customizeRetry()
     }
 
     install(ContentNegotiation) {

--- a/src/main/kotlin/no/nav/fager/texas/Texas.kt
+++ b/src/main/kotlin/no/nav/fager/texas/Texas.kt
@@ -2,6 +2,7 @@ package no.nav.fager.texas
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.bearerAuth
@@ -123,8 +124,18 @@ data class TexasAuthConfig(
 class AuthClient(
     private val config: TexasAuthConfig,
     private val provider: IdentityProvider,
-    private val httpClient: HttpClient = defaultHttpClient(),
+    private val timeoutMillis: Long = 1_000
 ) {
+
+    private val httpClient: HttpClient = defaultHttpClient(
+        customizeRetry = { retryOnServerErrors(0) },
+    ) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = timeoutMillis
+            connectTimeoutMillis = timeoutMillis
+            socketTimeoutMillis = timeoutMillis
+        }
+    }
 
     suspend fun token(target: String): TokenResponse = try {
         withTimer("texas_auth_token").coRecord {

--- a/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/fager/AltinnServiceTest.kt
@@ -9,8 +9,12 @@ import no.nav.fager.altinn.ResourceRegistry
 import no.nav.fager.fakes.clients.FakeAltinn3Client
 import no.nav.fager.fakes.clients.FakeRedisClient
 import no.nav.fager.redis.RedisConfig
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AltinnServiceTest {
     @Test
@@ -564,4 +568,46 @@ class AltinnServiceTest {
         assertEquals("2.1", tilganger2.altinnTilganger.first().underenheter.first().orgnr)
     }
 
+    @Test
+    fun `feil fra altinn3 logges som error uten fnr og gir isError uten å kaste`() = runTest {
+        val altinnRedisClient = FakeRedisClient()
+        val altinn3Client = FakeAltinn3Client(resourceOwner_AuthorizedPartiesHandler = {
+            throw RuntimeException("boom fra altinn 3")
+        })
+        val resourceRegistry = ResourceRegistry(FakeAltinn3Client(), RedisConfig.local(), null).also {
+            it.updatePolicySubjectsForKnownResources { listOf() }
+        }
+
+        val altinnService = AltinnService(altinn3Client, altinnRedisClient, resourceRegistry)
+
+        val fnr = "26903848935"
+        lateinit var resultat: AltinnTilgangerResultat
+        val stdout = captureStdout {
+            resultat = altinnService.hentTilganger(fnr, Filter.empty)
+        }
+
+        assertEquals(true, resultat.isError)
+        assertTrue(resultat.altinnTilganger.isEmpty())
+
+        val errorLines = stdout.lines().filter { it.contains("Klarte ikke hente authorizedParties fra Altinn 3") }
+        assertEquals(1, errorLines.size, "forventet nøyaktig én error-logglinje")
+        assertTrue(stdout.contains("boom fra altinn 3"), "forventet at exception-meldingen logges")
+        assertFalse(stdout.contains(fnr), "fnr skal ikke forekomme i loggen")
+    }
+
+}
+
+private inline fun captureStdout(block: () -> Unit): String {
+    val originalOut = System.out
+    val captured = try {
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        val printStream = PrintStream(byteArrayOutputStream, true)
+        System.setOut(printStream)
+        block()
+        byteArrayOutputStream.toString()
+    } finally {
+        System.setOut(originalOut)
+    }
+    print(captured)
+    return captured
 }

--- a/src/test/kotlin/no/nav/fager/HttpClientHardeningTest.kt
+++ b/src/test/kotlin/no/nav/fager/HttpClientHardeningTest.kt
@@ -1,0 +1,86 @@
+package no.nav.fager
+
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.ServerResponseException
+import io.ktor.client.request.get
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.network.sockets.SocketTimeoutException
+import io.ktor.server.response.respondText
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.fager.fakes.FakeApi
+import no.nav.fager.infrastruktur.defaultHttpClient
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+
+class HttpClientHardeningTest {
+
+    private fun withFakeApi(block: (FakeApi) -> Unit) {
+        FakeApi().use { fakeApi ->
+            runBlocking { fakeApi.start() }
+            block(fakeApi)
+        }
+    }
+
+    @Test
+    fun `customizeRetry med retryOnServerErrors 0 gir nøyaktig ett kall ved 500 fra server`() = withFakeApi { fakeApi ->
+        val calls = AtomicInteger(0)
+        fakeApi.stubs[HttpMethod.Get to "/boom"] = {
+            calls.incrementAndGet()
+            call.respondText("boom", status = HttpStatusCode.InternalServerError)
+        }
+
+        val client = defaultHttpClient(customizeRetry = { retryOnServerErrors(0) })
+
+        assertFailsWith<ServerResponseException> {
+            runBlocking { client.get("http://localhost:${fakeApi.port}/boom") }
+        }
+
+        assertEquals(1, calls.get(), "server-error skal ikke retryes når customizeRetry setter retryOnServerErrors(0)")
+    }
+
+    @Test
+    fun `default retryOnServerErrors gir fire kall ved 500 fra server`() = withFakeApi { fakeApi ->
+        val calls = AtomicInteger(0)
+        fakeApi.stubs[HttpMethod.Get to "/boom"] = {
+            calls.incrementAndGet()
+            call.respondText("boom", status = HttpStatusCode.InternalServerError)
+        }
+
+        val client = defaultHttpClient()
+
+        assertFailsWith<ServerResponseException> {
+            runBlocking { client.get("http://localhost:${fakeApi.port}/boom") }
+        }
+
+        assertEquals(4, calls.get(), "default skal gi 1 forsøk + 3 retries")
+    }
+
+    @Test
+    fun `retryOnExceptionIf retryer fortsatt ved SocketTimeoutException`() = withFakeApi { fakeApi ->
+        val calls = AtomicInteger(0)
+        val timeoutMs = 10L
+        fakeApi.stubs[HttpMethod.Get to "/treg"] = {
+            calls.incrementAndGet()
+            delay((timeoutMs + 10).milliseconds)
+            call.respondText("omsider", status = HttpStatusCode.OK)
+        }
+
+        val client = defaultHttpClient(configure = {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 60_000
+                socketTimeoutMillis = timeoutMs
+            }
+        })
+
+        assertFailsWith<SocketTimeoutException> {
+            runBlocking { client.get("http://localhost:${fakeApi.port}/treg") }
+        }
+
+        assertEquals(4, calls.get(), "socket timeout skal gi 1 forsøk + 3 retries")
+    }
+}

--- a/src/test/kotlin/no/nav/fager/TexasTest.kt
+++ b/src/test/kotlin/no/nav/fager/TexasTest.kt
@@ -21,8 +21,10 @@ import no.nav.fager.texas.TokenResponse
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.milliseconds
 
 class TexasTest {
 
@@ -71,6 +73,50 @@ class TexasTest {
         httpClient.get("/some/protected/endpoint")
         assertNotNull(fakeProtectedAPiEndpoint.requestHistory.lastOrNull()).apply {
             assertEquals("Bearer second_token", headers["authorization"])
+        }
+    }
+
+    @Test
+    fun `AuthClient retryer ikke ved 500 fra texas`() = testWithFakeApi { fakeTexas ->
+        val calls = java.util.concurrent.atomic.AtomicInteger(0)
+        fakeTexas.stubs[HttpMethod.Post to "/token"] = {
+            calls.incrementAndGet()
+            call.respondText(
+                //language=json
+                """{"error": "server_error", "error_description": "maskinporten timeout"}""",
+                ContentType.Application.Json,
+                HttpStatusCode.InternalServerError,
+            )
+        }
+
+        val texasAuthConfig = TexasAuthConfig.fake(fakeTexas)
+        val authClient = AuthClient(texasAuthConfig, IdentityProvider.MASKINPORTEN)
+
+        val response = authClient.token("1234")
+
+        assertEquals(1, calls.get(), "texas 5xx skal ikke retryes av AuthClient")
+        assertNotNull(response as? TokenResponse.Error).apply {
+            assertEquals(HttpStatusCode.InternalServerError, status)
+        }
+    }
+
+    @Test
+    fun `AuthClient har request-timeout mot texas`() = testWithFakeApi { fakeTexas ->
+        val timeoutMs = 10L
+        fakeTexas.stubs[HttpMethod.Post to "/token"] = {
+            kotlinx.coroutines.delay((timeoutMs + 10).milliseconds)
+            call.respondText(
+                //language=json
+                """{"access_token": "sent", "expires_in": 3600}""",
+                ContentType.Application.Json,
+            )
+        }
+
+        val texasAuthConfig = TexasAuthConfig.fake(fakeTexas)
+        val authClient = AuthClient(texasAuthConfig, IdentityProvider.MASKINPORTEN, timeoutMs)
+
+        assertFailsWith<io.ktor.client.plugins.HttpRequestTimeoutException> {
+            authClient.token("1234")
         }
     }
 


### PR DESCRIPTION
During the 2026-08-05 ID-porten DDoS, a single POST /altinn-tilganger spent 13.65 s looping on texas /api/v1/token because two retry cycles multiplied: texas retried Maskinporten internally while defaultHttpClient retried texas. The failure was then swallowed by runCatching + onFailure = { emptyList() }, returning HTTP 200 with an empty result and no ERROR log to alert on.

- Http.kt: add customizeRetry block to defaultHttpClient, matching the existing customizeLogging/customizeMetrics pattern, invoked after the defaults so callers can override retry behaviour.
- Texas.kt: AuthClient now uses customizeRetry = { retryOnServerErrors(0) } so texas 5xx (already-exhausted) responses are not retried, and installs an explicit 1000 ms HttpTimeout (request/connect/socket) via its configure block. retryOnExceptionIf network retries are unchanged.
- AltinnService.kt: log.error on Altinn 3 failure so the graceful emptyList fallback still emits an alertable ERROR line (no fnr in the message).

Altinn3Client's existing 60 000 ms timeout is intentionally left untouched.